### PR TITLE
export cljs->js and js->cljs

### DIFF
--- a/spec/mori-spec.js
+++ b/spec/mori-spec.js
@@ -164,3 +164,25 @@ describe("Juxtaposition", function () {
     });
 
 });
+
+describe("Conversion utilities", function () {
+
+    it("demonstrates conversion from clojurescript values to javascript objects, and vice versa", function () {
+
+        var js_obj  = { a: 1, b: "two" },
+            js_arr  = [1, 2, 3],
+            clj_map = mori.hash_map("a", 1, "b", "two"),
+            clj_vec = mori.vector(1, 2, 3);
+
+
+        expect(mori.equals(mori.js_to_clj(js_obj), clj_map)).toBe(true);
+
+        expect(mori.equals(mori.js_to_clj(js_arr), clj_vec)).toBe(true);
+
+        expect(mori.clj_to_js(clj_map)).toEqual(js_obj);
+
+        expect(mori.clj_to_js(clj_vec)).toEqual(js_arr);
+
+    });
+
+});

--- a/src/mori.cljs
+++ b/src/mori.cljs
@@ -125,3 +125,6 @@
 
 (def ^:export identity cljs.core/identity)
 (def ^:export constantly cljs.core/constantly)
+
+(def ^:export clj-to-js cljs.core/clj->js)
+(def ^:export js-to-clj cljs.core/js->clj)


### PR DESCRIPTION
`mori` now exports the helpful utility functions for converting between ClojureScript values and JavaScript objects.

`clj->js` is usable as `clj_to_js` from JavaScript. `js->clj` is usable as `js_to_clj` from JavaScript.

Implemented simple tests for those utilities.

Builds work fine, tests pass.
