### PR TITLE
Make the documented functions take-while, drop-while and group-by accessible from JavaScript

### DIFF
--- a/src/mori.cljs
+++ b/src/mori.cljs
@@ -3,6 +3,7 @@
    [count empty first rest seq conj cons find nth last assoc dissoc
     get-in update-in assoc-in fnil disj pop peek hash get contains? empty? reverse
     take drop partition partition-by iterate into subvec
+    take-while drop-while group-by
     interpose interleave concat flatten
     keys vals
     prim-seq
@@ -48,6 +49,9 @@
 (def ^:export iterate cljs.core/iterate)
 (def ^:export into cljs.core/into)
 (def ^:export subvec cljs.core/subvec)
+(def ^:export take-while cljs.core/take-while)
+(def ^:export drop-while cljs.core/drop-while)
+(def ^:export group-by cljs.core/group-by)
 (def ^:export interpose cljs.core/interpose)
 (def ^:export interleave cljs.core/interleave)
 (def ^:export concat cljs.core/concat)


### PR DESCRIPTION
The documentation at http://swannodette.github.io/mori/ mentions these three functions, which were however not being exported from `mori.cljs`.
