### PR TITLE
Additions and fixes to the API documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1609,7 +1609,7 @@ f(["FoO", "bAr"]); // => ["foo", "BAR"]
 
             <h3 id="pipeline">
                 pipeline
-                <span class="sig">mori.knit(x, f0, f1, ...)</span>
+                <span class="sig">mori.pipeline(x, f0, f1, ...)</span>
             </h3>
             <p>
                 Allows threading a value through a series of functions.


### PR DESCRIPTION
All functions except `js_to_clj`, `clj_to_js` and the ones concerned with reducers are now documented. A number of small issues, mostly typos, within the existing docs have been fixed.
