### PR TITLE
make keywords inspectable

### DIFF
--- a/src/mori.cljs
+++ b/src/mori.cljs
@@ -234,5 +234,6 @@
   cljs.core.PersistentTreeMap
   cljs.core.PersistentHashSet
   cljs.core.PersistentTreeSet
-  cljs.core.Range)
+  cljs.core.Range
+  cljs.core.Keyword)
 


### PR DESCRIPTION
`console.log(_.keyword('test'))` -> `:test`
