### PR TITLE
Improve juxt example and document sorted_map

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,7 +288,7 @@ m = mori;
 
 [1 2 3 4]            ;; vector
 
-{"foo" 1, "bar" 2}     ;; hash map
+{"foo" 1, "bar" 2}     ;; hash map / sorted-map
 
 #{"cat" "bird" "dog"}  ;; set / sorted-set
           </pre>
@@ -502,6 +502,19 @@ var m1 = mori.assoc(m0, m.vector(1,2), 3);
 // m1 = {"foo" 1, "bar" 2, [1 2] 3}
 
 mori.get(m1, m.vector(1,2)); // => 3
+          </pre>
+        </div>
+
+        <h3 id="sorted_map">
+          sorted_map
+          <span class="sig">mori.sorted_map(key0, val0, key1, val1, ...)</span>
+        </h3>
+        <p>
+          Like a hash map but keeps its keys ordered.
+        </p>
+        <div class="example">
+          <pre class="brush: clojure">
+mori.sorted_map(2, "two", 3, "three", 1, "one"); // {1 "one", 2 "two", 3 "three"}
           </pre>
         </div>
 


### PR DESCRIPTION
I noticed sorted map was undocumented so figured I might as well bundle it in with the other change while I was there.
