### PR TITLE
Add some more sequence functions

### DIFF
--- a/spec/mori-spec.js
+++ b/spec/mori-spec.js
@@ -110,7 +110,7 @@ describe("Currying", function () {
 
         var cur_res = mori.pipeline(mori.vector(1,2,3),
                                     mori.curry(mori.conj, 4),
-                                    mori.curry(mori.conj, 5));;
+                                    mori.curry(mori.conj, 5));
 
         expect(mori.into_array(cur_res)).toEqual([1,2,3,4,5]);
 
@@ -245,4 +245,23 @@ describe("Queue", function() {
 
     });
 
+});
+
+describe("lazy-seq", function() {
+    it("can be used build non-stack-blowing seq functions", function() {
+        var m = mori;
+        var fib = function(a, b) {
+            return m.cons(a, m.lazy_seq(function() {
+                return fib(b, b + a);
+            }));
+        };
+
+        var fibs = m.take(10, fib(1, 1));
+
+        expect(m.clj_to_js(fibs)).toEqual([1, 1, 2, 3, 5, 8, 13, 21, 34, 55]);
+
+        // Numbers can only be so big
+        var bigFib = m.last(m.take(2000, fib(1, 1)));
+        expect(bigFib).toEqual(Infinity);
+    });
 });

--- a/src/mori.cljs
+++ b/src/mori.cljs
@@ -2,11 +2,12 @@
   (:refer-clojure :exclude
    [count distinct empty first rest seq conj cons find nth last assoc dissoc
     get-in update-in assoc-in fnil disj pop peek hash get empty? reverse
-    take drop partition partition-by iterate into merge subvec
+    take drop take-nth partition partition-all partition-by iterate
+    into merge subvec
     take-while drop-while group-by
     interpose interleave concat flatten
     keys select-keys vals
-    prim-seq
+    prim-seq lazy-seq
     map mapcat reduce reduce-kv filter remove some every? equiv
     range repeat repeatedly sort sort-by
     into-array
@@ -49,7 +50,9 @@
 (def ^:export reverse cljs.core/reverse)
 (def ^:export take cljs.core/take)
 (def ^:export drop cljs.core/drop)
+(def ^:export take-nth cljs.core/take-nth)
 (def ^:export partition cljs.core/partition)
+(def ^:export partition-all cljs.core/partition-all)
 (def ^:export partition-by cljs.core/partition-by)
 (def ^:export iterate cljs.core/iterate)
 (def ^:export into cljs.core/into)
@@ -72,6 +75,10 @@
 (defn ^:export flatten [x]
   (cljs.core/filter #(not (sequential-or-array? %))
     (cljs.core/rest (tree-seq sequential-or-array? seq x))))
+
+; The real lazy-seq is a macro, but it just expands its body into a function
+(defn ^:export lazy-seq [f]
+  (new cljs.core/LazySeq nil f nil nil))
 
 (def ^:export keys cljs.core/keys)
 (def ^:export select-keys cljs.core/select-keys)


### PR DESCRIPTION
While building a react app I found myself wanting `partition-all` and `take-nth`, so I've added them here.

I initially ported the implementations into my app, but ended up implementing as eager recursion as `lazy-seq` was not available - so here it is too.

I'll update the docs too soon - how would you feel about putting the docs in master with a script to update gh-pages? I think this would make it easier to keep them in sync.
