### PR TITLE
expose *print-depth* and *print-length* knobs

### DIFF
--- a/spec/mori-spec.js
+++ b/spec/mori-spec.js
@@ -203,6 +203,29 @@ describe("Distinct", function() {
 
 });
 
+describe("configure", function() {
+    it("can tune *print-length*", function() {
+        mori.configure("print-length", 5);
+        expect(mori.range(10).toString()).toEqual("(0 1 2 3 4 ...)");
+
+        mori.configure("print-length", 3);
+        expect(mori.range(5).toString()).toEqual("(0 1 2 ...)");
+
+        mori.configure("print-length", null);
+        expect(mori.range(5).toString()).toEqual("(0 1 2 3 4)");
+    });
+    it("can tune *print-level*", function() {
+        mori.configure("print-level", 3);
+        expect(mori.parse("[1 [2 [3 [4 [5]]]]]") + '').toEqual("[1 [2 [3 #]]]");
+
+        mori.configure("print-level", 1);
+        expect(mori.parse("{1 {2 3}}") + '').toEqual("{1 #}");
+
+        mori.configure("print-level", null);
+        expect(mori.parse("[1 [2 [3 [4]]]]") + '').toEqual("[1 [2 [3 [4]]]]");
+    });
+});
+
 describe("Queue", function() {
 
     it("can be initialized empty", function() {

--- a/src/mori.cljs
+++ b/src/mori.cljs
@@ -183,12 +183,17 @@
 (def ^:export constantly cljs.core/constantly)
 
 (def ^:export clj-to-js cljs.core/clj->js)
-(defn ^:export js-to-clj 
+(defn ^:export js-to-clj
   ([x] (cljs.core/js->clj x))
   ([x keywordize-keys] (cljs.core/js->clj x :keywordize-keys keywordize-keys)))
 
 (defn ^:export parse [s]
   (reader/read-string s))
+
+(defn ^:export configure [variable value]
+  (case variable
+    "print-length" (set! *print-length* value)
+    "print-level" (set! *print-level* value)))
 
 ;; =============================================================================
 ;; Experimental Proxy support


### PR DESCRIPTION
Fixes #68

I was going to make something more general, but with `(set!)` being a special form, the case statement seemed to be the easiest option.
