### PR TITLE
Transducers, mori.reducers

### DIFF
--- a/spec/mori-spec.js
+++ b/spec/mori-spec.js
@@ -80,7 +80,7 @@ describe("Reducers", function () {
         //     console.log(((new Date())-s)+"ms");
         // }
 
-        var res1 = m.reduce(m.sum, 0, m.rmap(m.inc, m.rfilter(m.is_even, m.rmap(mul3, v)))),
+        var res1 = m.reduce(m.sum, 0, m.reducers.map(m.inc, m.reducers.filter(m.is_even, m.reducers.map(mul3, v)))),
             res2 = a.map(mul3).filter(m.is_even).map(m.inc).reduce(m.sum);
 
         expect(res1).toEqual(7499900000);

--- a/src/mori.cljs
+++ b/src/mori.cljs
@@ -9,6 +9,7 @@
     keys select-keys vals
     prim-seq lazy-seq
     map mapcat map-indexed reduce reduce-kv filter remove some every? equiv
+    transduce iteration sequence flatmap dedupe
     range repeat repeatedly sort sort-by
     into-array
     partial comp juxt
@@ -20,7 +21,6 @@
   (:use-macros [mori.macros :only [make-inspectable]])
   (:require [clojure.set :as set]
             [clojure.data :as data]
-            [clojure.core.reducers :as reducers]
             [cljs.reader :as reader]))
 
 (def ^:export apply cljs.core/apply)
@@ -105,15 +105,14 @@
 (def ^:export sort-by cljs.core/sort-by)
 (def ^:export into-array cljs.core/into-array)
 (def ^:export subseq cljs.core/subseq)
+(def ^:export flatmap cljs.core/flatmap)
+(def ^:export dedupe cljs.core/dedupe)
 
-;; Reducers
-(def ^:export rmap reducers/map)
-(def ^:export rfilter reducers/filter)
-(def ^:export rremove reducers/remove)
-(def ^:export rtake reducers/take)
-(def ^:export rtake-while reducers/take-while)
-(def ^:export rdrop reducers/drop)
-(def ^:export rflatten reducers/flatten)
+;; transducers
+
+(def ^:export transduce cljs.core/transduce)
+(def ^:export iteration cljs.core/iteration)
+(def ^:export sequence cljs.core/sequence)
 
 ;; constructors
 

--- a/src/mori/reducers.cljs
+++ b/src/mori/reducers.cljs
@@ -1,0 +1,13 @@
+(ns mori.reducers
+  (:refer-clojure :exclude 
+    [map filter remove take take-while drop flatten])
+  (:require [clojure.core.reducers :as reducers]))
+
+;; Reducers
+(def ^:export map reducers/map)
+(def ^:export filter reducers/filter)
+(def ^:export remove reducers/remove)
+(def ^:export take reducers/take)
+(def ^:export take-while reducers/take-while)
+(def ^:export drop reducers/drop)
+(def ^:export flatten reducers/flatten)


### PR DESCRIPTION
Adds mori.reducers namespace, moving r prefixed fns to this namespace. Adds tranduce and related transducer functions.
