### PR TITLE
remove extraneous seq wrapper

### DIFF
--- a/index.html
+++ b/index.html
@@ -549,7 +549,7 @@ mori.conj(s, "zebra"); // => #{"bird" "cat" "dog" "zebra"}
         </p>
         <div class="example">
           <pre class="brush: clojure">
-mori.seq(mori.sorted_set(3,2,1,3)); // #{1 2 3}
+mori.sorted_set(3,2,1,3); // #{1 2 3}
           </pre>
         </div>
 


### PR DESCRIPTION
`mori.sorted_set` example was unnecessarily wrapped in `mori.seq`, causing result to differ from that shown in the comment.
