### PR TITLE
Rename exported functions to be more idiomatic for js

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ var inc = function(n) {
   return n+1;
 };
 
-mori.into_array(mori.map(inc, mori.vector(1,2,3,4,5)));
+mori.intoArray(mori.map(inc, mori.vector(1,2,3,4,5)));
 // => [2,3,4,5,6]
 ```
 
@@ -96,7 +96,7 @@ Lazy sequences!
 
 ```javascript
 var _ = mori;
-_.into_array(_.interpose("foo", _.vector(1, 2, 3, 4)));
+_.intoArray(_.interpose("foo", _.vector(1, 2, 3, 4)));
 // => [1, "foo", 2, "foo", 3, "foo", 4]
 ```
 
@@ -105,7 +105,7 @@ Or if it's more your speed, use it from CoffeeScript!
 ```coffeescript
 inc = (x) -> x+1  
 r = mori.map inc, mori.vector(1,2,3,4,5)
-mori.into_array r
+mori.intoArray r
 ```
 
 ### Documentation
@@ -159,7 +159,7 @@ return the proposed mutable iterators:
 
 ```javascript
 var m = mori;
-var h = m.hash_map("foo", 1, "bar", 2);
+var h = m.hashMap("foo", 1, "bar", 2);
 
 h.has("foo"); // => true
 h.get("foo"); // => 1
@@ -248,11 +248,11 @@ second(mori.vector(1,2,3));
 ### Juxtaposition
 
 ```javascript
-var pos_and_neg = mori.juxt(mori.identity, function (v) { return -v; });
-pos_and_neg(1);
+var posAndNeg = mori.juxt(mori.identity, function (v) { return -v; });
+posAndNeg(1);
 // => [1 -1]
 
-mori.knit(mori.inc, mori.dec)(pos_and_neg(1));
+mori.knit(mori.inc, mori.dec)(posAndNeg(1));
 // => [2 -2]
 ```
 

--- a/spec/mori-spec.js
+++ b/spec/mori-spec.js
@@ -5,9 +5,9 @@ describe("Map", function () {
     it("demonstrates mapping a function over a vector", function () {
 
         var inc = function (n) { return n + 1; },
-            out_arr = mori.into_array(mori.map(inc, mori.vector(1,2,3,4,5)));
+            outArr = mori.intoArray(mori.map(inc, mori.vector(1,2,3,4,5)));
 
-        expect(out_arr).toEqual([2,3,4,5,6]);
+        expect(outArr).toEqual([2,3,4,5,6]);
 
     });
 
@@ -20,8 +20,8 @@ describe("Non-destructive update", function () {
         var v1 = mori.vector(1,2,3),
             v2 = mori.conj(v1, 4);
 
-        expect(JSON.stringify(mori.into_array(v1))).toEqual("[1,2,3]");
-        expect(JSON.stringify(mori.into_array(v2))).toEqual("[1,2,3,4]");
+        expect(JSON.stringify(mori.intoArray(v1))).toEqual("[1,2,3]");
+        expect(JSON.stringify(mori.intoArray(v2))).toEqual("[1,2,3,4]");
 
     });
 
@@ -49,7 +49,7 @@ describe("Lazy sequences", function () {
 
         var _ = mori;
 
-        var interposed = _.into_array(_.interpose("foo", _.vector(1, 2, 3, 4)));
+        var interposed = _.intoArray(_.interpose("foo", _.vector(1, 2, 3, 4)));
 
         expect(interposed).toEqual([1, "foo", 2, "foo", 3, "foo", 4]);
 
@@ -80,8 +80,8 @@ describe("Reducers", function () {
         //     console.log(((new Date())-s)+"ms");
         // }
 
-        var res1 = m.reduce(m.sum, 0, m.reducers.map(m.inc, m.reducers.filter(m.is_even, m.reducers.map(mul3, v)))),
-            res2 = a.map(mul3).filter(m.is_even).map(m.inc).reduce(m.sum);
+        var res1 = m.reduce(m.sum, 0, m.reducers.map(m.inc, m.reducers.filter(m.isEven, m.reducers.map(mul3, v)))),
+            res2 = a.map(mul3).filter(m.isEven).map(m.inc).reduce(m.sum);
 
         expect(res1).toEqual(7499900000);
         expect(res2).toEqual(res1);
@@ -94,11 +94,11 @@ describe("Pipelines", function () {
 
     it("demonstrates function pipelining", function () {
 
-        var pipe_res = mori.pipeline(mori.vector(1,2,3),
+        var pipeRes = mori.pipeline(mori.vector(1,2,3),
                                      function(v) { return mori.conj(v,4); },
                                      function(v) { return mori.drop(2, v); });
 
-        expect(mori.into_array(pipe_res)).toEqual([3,4]);
+        expect(mori.intoArray(pipeRes)).toEqual([3,4]);
 
     });
 
@@ -108,11 +108,11 @@ describe("Currying", function () {
 
     it("demonstrates function currying", function () {
 
-        var cur_res = mori.pipeline(mori.vector(1,2,3),
+        var curRes = mori.pipeline(mori.vector(1,2,3),
                                     mori.curry(mori.conj, 4),
                                     mori.curry(mori.conj, 5));
 
-        expect(mori.into_array(cur_res)).toEqual([1,2,3,4,5]);
+        expect(mori.intoArray(curRes)).toEqual([1,2,3,4,5]);
 
     });
 
@@ -122,11 +122,11 @@ describe("Partial application", function () {
 
     it("demonstrates partial function application", function () {
 
-        var par_res = mori.pipeline(mori.vector(1,2,3),
+        var parRes = mori.pipeline(mori.vector(1,2,3),
                                     mori.curry(mori.conj, 4),
                                     mori.partial(mori.drop, 2));
 
-        expect(mori.into_array(par_res)).toEqual([3, 4]);
+        expect(mori.intoArray(parRes)).toEqual([3, 4]);
 
     });
 
@@ -139,9 +139,9 @@ describe("Function composition", function () {
 
         var second = mori.comp(mori.first, mori.rest);
 
-        var sec_res = second(mori.vector(1,2,3));
+        var secRes = second(mori.vector(1,2,3));
 
-        expect(sec_res).toEqual(2);
+        expect(secRes).toEqual(2);
 
     });
 
@@ -151,15 +151,15 @@ describe("Juxtaposition", function () {
 
     it("demonstrates function juxtaposition", function () {
 
-        var pos_and_neg = mori.juxt(mori.identity, function (v) { return -v; });
+        var posAndNeg = mori.juxt(mori.identity, function (v) { return -v; });
 
-        var pn_res = pos_and_neg(1);
+        var pnRes = posAndNeg(1);
 
-        expect(mori.into_array(pn_res)).toEqual([1,-1]);
+        expect(mori.intoArray(pnRes)).toEqual([1,-1]);
 
-        var knit_res = mori.knit(mori.inc, mori.dec)(pos_and_neg(1));
+        var knitRes = mori.knit(mori.inc, mori.dec)(posAndNeg(1));
 
-        expect(mori.into_array(knit_res)).toEqual([2,-2]);
+        expect(mori.intoArray(knitRes)).toEqual([2,-2]);
 
     });
 
@@ -169,22 +169,22 @@ describe("Conversion utilities", function () {
 
     it("demonstrates conversion from clojurescript values to javascript objects, and vice versa", function () {
 
-        var js_obj  = { a: 1, b: "two" },
-            js_arr  = [1, 2, 3],
-            clj_map = mori.hash_map("a", 1, "b", "two"),
-            clj_map_keywordized = mori.hash_map(mori.keyword("a"), 1, mori.keyword("b"), "two"),
-            clj_vec = mori.vector(1, 2, 3);
+        var jsObj  = { a: 1, b: "two" },
+            jsArr  = [1, 2, 3],
+            cljMap = mori.hashMap("a", 1, "b", "two"),
+            cljMapKeywordized = mori.hashMap(mori.keyword("a"), 1, mori.keyword("b"), "two"),
+            cljVec = mori.vector(1, 2, 3);
 
-        expect(mori.equals(mori.js_to_clj(js_obj), clj_map)).toBe(true);
-        expect(mori.equals(mori.js_to_clj(js_obj,true), clj_map_keywordized)).toBe(true);
+        expect(mori.equals(mori.toClj(jsObj), cljMap)).toBe(true);
+        expect(mori.equals(mori.toClj(jsObj,true), cljMapKeywordized)).toBe(true);
 
-        expect(mori.equals(mori.js_to_clj(js_arr), clj_vec)).toBe(true);
+        expect(mori.equals(mori.toClj(jsArr), cljVec)).toBe(true);
 
-        expect(mori.clj_to_js(clj_map)).toEqual(js_obj);
+        expect(mori.toJs(cljMap)).toEqual(jsObj);
 
-        expect(mori.clj_to_js(clj_vec)).toEqual(js_arr);
+        expect(mori.toJs(cljVec)).toEqual(jsArr);
 
-        expect(mori.is_vector(mori.js_to_clj(js_arr))).toBe(true);
+        expect(mori.isVector(mori.toClj(jsArr))).toBe(true);
 
     });
 
@@ -195,9 +195,9 @@ describe("Distinct", function() {
 
     var vec = mori.vector(1,1,1,1,2,2,3,4,5,6,6);
 
-    var distinct_vector = mori.distinct(vec);
+    var distinctVector = mori.distinct(vec);
 
-    expect(mori.clj_to_js(distinct_vector)).toEqual([1,2,3,4,5,6]);
+    expect(mori.toJs(distinctVector)).toEqual([1,2,3,4,5,6]);
 
   });
 
@@ -232,7 +232,7 @@ describe("Queue", function() {
 
         var q = mori.queue();
 
-        expect(mori.is_empty(q)).toBeTruthy();
+        expect(mori.isEmpty(q)).toBeTruthy();
 
     });
 
@@ -240,7 +240,7 @@ describe("Queue", function() {
 
         var q = mori.queue('a', 'b');
 
-        expect(mori.is_empty(q)).toBeFalsy();
+        expect(mori.isEmpty(q)).toBeFalsy();
         expect(mori.peek(q)).toEqual('a');
 
     });
@@ -251,14 +251,14 @@ describe("lazy-seq", function() {
     it("can be used build non-stack-blowing seq functions", function() {
         var m = mori;
         var fib = function(a, b) {
-            return m.cons(a, m.lazy_seq(function() {
+            return m.cons(a, m.lazySeq(function() {
                 return fib(b, b + a);
             }));
         };
 
         var fibs = m.take(10, fib(1, 1));
 
-        expect(m.clj_to_js(fibs)).toEqual([1, 1, 2, 3, 5, 8, 13, 21, 34, 55]);
+        expect(m.toJs(fibs)).toEqual([1, 1, 2, 3, 5, 8, 13, 21, 34, 55]);
 
         // Numbers can only be so big
         var bigFib = m.last(m.take(2000, fib(1, 1)));

--- a/src/mori.cljs
+++ b/src/mori.cljs
@@ -40,32 +40,32 @@
 (def ^:export last cljs.core/last)
 (def ^:export assoc cljs.core/assoc)
 (def ^:export dissoc cljs.core/dissoc)
-(def ^:export get-in cljs.core/get-in)
-(def ^:export update-in cljs.core/update-in)
-(def ^:export assoc-in cljs.core/assoc-in)
+(def ^:export getIn cljs.core/get-in)
+(def ^:export updateIn cljs.core/update-in)
+(def ^:export assocIn cljs.core/assoc-in)
 (def ^:export fnil cljs.core/fnil)
 (def ^:export disj cljs.core/disj)
 (def ^:export pop cljs.core/pop)
 (def ^:export peek cljs.core/peek)
 (def ^:export hash cljs.core/hash)
 (def ^:export get cljs.core/get)
-(def ^:export has-key cljs.core/contains?)
-(def ^:export is-empty cljs.core/empty?)
+(def ^:export hasKey cljs.core/contains?)
+(def ^:export isEmpty cljs.core/empty?)
 (def ^:export reverse cljs.core/reverse)
 (def ^:export take cljs.core/take)
 (def ^:export drop cljs.core/drop)
-(def ^:export take-nth cljs.core/take-nth)
+(def ^:export takeNth cljs.core/take-nth)
 (def ^:export partition cljs.core/partition)
-(def ^:export partition-all cljs.core/partition-all)
-(def ^:export partition-by cljs.core/partition-by)
+(def ^:export partitionAall cljs.core/partition-all)
+(def ^:export partitionBy cljs.core/partition-by)
 (def ^:export iterate cljs.core/iterate)
 (def ^:export into cljs.core/into)
 (def ^:export merge cljs.core/merge)
-(def ^:export merge-with cljs.core/merge-with)
+(def ^:export mergeWith cljs.core/merge-with)
 (def ^:export subvec cljs.core/subvec)
-(def ^:export take-while cljs.core/take-while)
-(def ^:export drop-while cljs.core/drop-while)
-(def ^:export group-by cljs.core/group-by)
+(def ^:export takeWhile cljs.core/take-while)
+(def ^:export dropWhile cljs.core/drop-while)
+(def ^:export groupBy cljs.core/group-by)
 (def ^:export interpose cljs.core/interpose)
 (def ^:export interleave cljs.core/interleave)
 (def ^:export concat cljs.core/concat)
@@ -82,20 +82,20 @@
     (cljs.core/rest (tree-seq sequential-or-array? seq x))))
 
 ; The real lazy-seq is a macro, but it just expands its body into a function
-(defn ^:export lazy-seq [f]
+(defn ^:export lazySeq [f]
   (new cljs.core/LazySeq nil f nil nil))
 
 (def ^:export keys cljs.core/keys)
-(def ^:export select-keys cljs.core/select-keys)
+(def ^:export selectKeys cljs.core/select-keys)
 (def ^:export vals cljs.core/vals)
-(def ^:export prim-seq cljs.core/prim-seq)
+(def ^:export primSeq cljs.core/prim-seq)
 (def ^:export map cljs.core/map)
-(def ^:export map-indexed cljs.core/map-indexed)
+(def ^:export mapIndexed cljs.core/map-indexed)
 (def ^:export mapcat cljs.core/mapcat)
 (def ^:export reduce cljs.core/reduce)
-(def ^:export reduce-kv cljs.core/reduce-kv)
+(def ^:export reduceKV cljs.core/reduce-kv)
 (def ^:export keep cljs.core/keep)
-(def ^:export keep-indexed cljs.core/keep-indexed)
+(def ^:export keepIndexed cljs.core/keep-indexed)
 (def ^:export filter cljs.core/filter)
 (def ^:export remove cljs.core/remove)
 (def ^:export some cljs.core/some)
@@ -105,8 +105,8 @@
 (def ^:export repeat cljs.core/repeat)
 (def ^:export repeatedly cljs.core/repeatedly)
 (def ^:export sort cljs.core/sort)
-(def ^:export sort-by cljs.core/sort-by)
-(def ^:export into-array cljs.core/into-array)
+(def ^:export sortBy cljs.core/sort-by)
+(def ^:export intoArray cljs.core/into-array)
 (def ^:export subseq cljs.core/subseq)
 (def ^:export flatmap cljs.core/flatmap)
 (def ^:export dedupe cljs.core/dedupe)
@@ -121,13 +121,13 @@
 
 (def ^:export list cljs.core/list)
 (def ^:export vector cljs.core/vector)
-(def ^:export array-map cljs.core/array-map)
-(def ^:export hash-map cljs.core/hash-map)
+(def ^:export arrayMap cljs.core/array-map)
+(def ^:export hashMap cljs.core/hash-map)
 (def ^:export set cljs.core/set)
-(def ^:export sorted-set cljs.core/sorted-set)
-(def ^:export sorted-set-by cljs.core/sorted-set-by)
-(def ^:export sorted-map cljs.core/sorted-map)
-(def ^:export sorted-map-by cljs.core/sorted-map-by)
+(def ^:export sortedSet cljs.core/sorted-set)
+(def ^:export sortedSetBy cljs.core/sorted-set-by)
+(def ^:export sortedMap cljs.core/sorted-map)
+(def ^:export sortedMapBy cljs.core/sorted-map-by)
 (def ^:export queue (fn [& args] (into cljs.core.PersistentQueue.EMPTY args)))
 
 (def ^:export keyword cljs.core/keyword)
@@ -136,23 +136,23 @@
 (def ^:export zipmap cljs.core/zipmap)
 
 ;; Predicates
-(def ^:export is-list cljs.core/list?)
-(def ^:export is-seq cljs.core/seq?)
-(def ^:export is-vector cljs.core/vector?)
-(def ^:export is-map cljs.core/map?)
-(def ^:export is-set cljs.core/set?)
+(def ^:export isList cljs.core/list?)
+(def ^:export isSeq cljs.core/seq?)
+(def ^:export isVector cljs.core/vector?)
+(def ^:export isMap cljs.core/map?)
+(def ^:export isSet cljs.core/set?)
 
-(def ^:export is-keyword cljs.core/keyword?)
-(def ^:export is-symbol cljs.core/symbol?)
+(def ^:export isKeyword cljs.core/keyword?)
+(def ^:export isSymbol cljs.core/symbol?)
 
-(def ^:export is-collection cljs.core/coll?)
-(def ^:export is-sequential cljs.core/sequential?)
-(def ^:export is-associative cljs.core/associative?)
-(def ^:export is-counted cljs.core/counted?)
-(def ^:export is-indexed cljs.core/indexed?)
-(def ^:export is-reduceable cljs.core/reduceable?)
-(def ^:export is-seqable cljs.core/seqable?)
-(def ^:export is-reversible cljs.core/reversible?)
+(def ^:export isCollection cljs.core/coll?)
+(def ^:export isSequential cljs.core/sequential?)
+(def ^:export isAssociative cljs.core/associative?)
+(def ^:export isCounted cljs.core/counted?)
+(def ^:export isIndexed cljs.core/indexed?)
+(def ^:export isReduceable cljs.core/reduceable?)
+(def ^:export isSeqable cljs.core/seqable?)
+(def ^:export isReversible cljs.core/reversible?)
 
 ;; Set ops
 (def ^:export union set/union)
@@ -161,15 +161,15 @@
 (def ^:export join set/join)
 (def ^:export index set/index)
 (def ^:export project set/project)
-(def ^:export map-invert set/map-invert)
+(def ^:export mapInvert set/map-invert)
 (def ^:export rename set/rename)
-(def ^:export rename-keys set/rename-keys)
-(def ^:export is-subset set/subset?)
-(def ^:export is-superset set/superset?)
+(def ^:export renameKeys set/rename-keys)
+(def ^:export isSubset set/subset?)
+(def ^:export isSuperset set/superset?)
 
 ;; Comparisons
 
-(def ^:export not-equals cljs.core/not=)
+(def ^:export notEquals cljs.core/not=)
 (def ^:export gt cljs.core/>)
 (def ^:export gte cljs.core/>=)
 (def ^:export lt cljs.core/<)
@@ -190,11 +190,11 @@
 
 (defn ^:export juxt [& fns]
   (fn [& args]
-    (into-array (map #(cljs.core/apply % args) fns))))
+    (intoArray (map #(cljs.core/apply % args) fns))))
 
 (defn ^:export knit [& fns]
   (fn [args]
-    (into-array (map #(% %2) fns args))))
+    (intoArray (map #(% %2) fns args))))
 
 ;; Data fns
 
@@ -205,8 +205,8 @@
 (def ^:export sum (fn [s n] (+ s n)))
 (def ^:export inc (fn [n] (+ n 1)))
 (def ^:export dec (fn [n] (- n 1)))
-(def ^:export is-even (fn [n] (zero? (mod n 2))))
-(def ^:export is-odd (fn [n] (== (mod n 2) 1)))
+(def ^:export isEven (fn [n] (zero? (mod n 2))))
+(def ^:export isOdd (fn [n] (== (mod n 2) 1)))
 
 (defn ^:export each [xs f]
   (doseq [x xs]
@@ -215,8 +215,8 @@
 (def ^:export identity cljs.core/identity)
 (def ^:export constantly cljs.core/constantly)
 
-(def ^:export clj-to-js cljs.core/clj->js)
-(defn ^:export js-to-clj
+(def ^:export cljToJs cljs.core/clj->js)
+(defn ^:export jsToClj
   ([x] (cljs.core/js->clj x))
   ([x keywordize-keys] (cljs.core/js->clj x :keywordize-keys keywordize-keys)))
 
@@ -229,10 +229,10 @@
     "print-level" (set! *print-level* value)))
 
 (def ^:export meta cljs.core/meta)
-(def ^:export with-meta cljs.core/with-meta)
-(def ^:export vary-meta cljs.core/vary-meta)
-(def ^:export alter-meta cljs.core/alter-meta!)
-(def ^:export reset-meta cljs.core/reset-meta!)
+(def ^:export withMeta cljs.core/with-meta)
+(def ^:export varyMeta cljs.core/vary-meta)
+(def ^:export alterMeta cljs.core/alter-meta!)
+(def ^:export resetMeta cljs.core/reset-meta!)
 
 ;; =============================================================================
 ;; Experimental Proxy support
@@ -251,14 +251,14 @@
                                   (count coll))
                                 :else v)))
                     "set" (fn [target k v])
-                    "enumerate" (fn [] (into-array (keys coll)))
+                    "enumerate" (fn [] (intoArray (keys coll)))
                     "keys" (fn []
                              (cond
                                (map? coll)
-                               (into-array (keys coll))
+                               (intoArray (keys coll))
 
                                (vector? coll)
-                               (into-array (range (count coll)))
+                               (intoArray (range (count coll)))
 
                                :else nil)))]
       (js/Proxy.create handler))

--- a/src/mori.cljs
+++ b/src/mori.cljs
@@ -56,7 +56,7 @@
 (def ^:export drop cljs.core/drop)
 (def ^:export takeNth cljs.core/take-nth)
 (def ^:export partition cljs.core/partition)
-(def ^:export partitionAall cljs.core/partition-all)
+(def ^:export partitionAll cljs.core/partition-all)
 (def ^:export partitionBy cljs.core/partition-by)
 (def ^:export iterate cljs.core/iterate)
 (def ^:export into cljs.core/into)
@@ -215,8 +215,8 @@
 (def ^:export identity cljs.core/identity)
 (def ^:export constantly cljs.core/constantly)
 
-(def ^:export cljToJs cljs.core/clj->js)
-(defn ^:export jsToClj
+(def ^:export toJs cljs.core/clj->js)
+(defn ^:export toClj
   ([x] (cljs.core/js->clj x))
   ([x keywordize-keys] (cljs.core/js->clj x :keywordize-keys keywordize-keys)))
 


### PR DESCRIPTION
Updates README as well.

This would obviously be a breaking change - perhaps the names should be added in *addition* to the previous names, and mark the previous ones as deprecated for a release or two? Or maybe it doesn't matter?