### PR TITLE
Fix missing naming convention update for `sortedMap` in docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -508,16 +508,16 @@ mori.get(m1, m.vector(1,2)); // => 3
           </pre>
         </div>
 
-        <h3 id="sorted_map">
-          sorted_map
-          <span class="sig">mori.sorted_map(key0, val0, key1, val1, ...)</span>
+        <h3 id="sortedMap">
+          sortedMap
+          <span class="sig">mori.sortedMap(key0, val0, key1, val1, ...)</span>
         </h3>
         <p>
           Like a hash map but keeps its keys ordered.
         </p>
         <div class="example">
           <pre class="brush: clojure">
-mori.sorted_map(2, "two", 3, "three", 1, "one"); // {1 "one", 2 "two", 3 "three"}
+mori.sortedMap(2, "two", 3, "three", 1, "one"); // {1 "one", 2 "two", 3 "three"}
           </pre>
         </div>
 


### PR DESCRIPTION
Must have been missed in dcd9c73d0c4fda60bcbacef6e6c63feb86776867