### PR TITLE
Fixes lein_prefer script

### DIFF
--- a/bin/get_lein.js
+++ b/bin/get_lein.js
@@ -1,19 +1,12 @@
 #!/usr/bin/env node
 
-var https = require("https"),
-    fs    = require("fs");
+var wget = require('wgetjs');
 
-var lein_loc = __dirname + "/lein";
-
-https.get("https://raw.github.com/technomancy/leiningen/stable/bin/lein", function(res) {
-    var body = "";
-    res.setEncoding("utf8");
-    res.on("data", function (chunk) {
-        body += chunk;
-    });
-    res.on("end", function () {
-        fs.writeFileSync(lein_loc, body);
-    });
-}).on("error", function(e) {
-    console.log("HTTP error: " + e.message);
+wget({
+    url: "https://raw.github.com/technomancy/leiningen/stable/bin/lein",
+    dest: __dirname + "/lein",
+}, function(err) {
+    if (err) {
+        console.log(err.message);
+    }
 });

--- a/bin/lein_prefer
+++ b/bin/lein_prefer
@@ -1,51 +1,42 @@
 #!/usr/bin/env bash
 
-LEIN_PREFER=`which lein`
-LEIN2=`which lein2`
+set -e
 
-if [[ ! -z $LEIN2 ]]; then
-
-LEIN_PREFER=$LEIN2
-
-fi
-
-if [[ ! -z $LEIN_PREFER ]]; then
-
-LEIN_VER=`$LEIN_PREFER version`
-
-fi
-
+LEIN_PREFER=""
+LEIN_VER=""
 LEIN_VER1_PATTERN="^Leiningen\ 1\."
+BIN=$(cd `dirname $0`; pwd)
 
-if [[ -z $LEIN_PREFER || $LEIN_VER =~ $LEIN_VER1_PATTERN ]]; then
+command_exists () {
+  type "$1" &>/dev/null
+}
 
-export LEIN_HOME=`pwd`"/bin/.lein"
+download_lein () {
+  "$BIN/get_lein.js"
+  chmod +x "$BIN/lein"
+  echo "$BIN/lein"
+}
 
-if [[ ! -d $LEIN_HOME ]]; then
-
-mkdir $LEIN_HOME
-
+if command_exists lein2; then
+  LEIN_PREFER=lein2
+elif command_exists lein; then
+  LEIN_PREFER=lein
+elif [ ! -x "$LEIN_PREFER" ]; then
+  LEIN_PREFER="$BIN/lein"
 fi
 
-LEIN_PREFER=`pwd`"/bin/lein"
-
+if [ -x "$LEIN_PREFER" ]; then
+  LEIN_VER=$("$LEIN_PREFER" version)
 fi
 
-if [[ ! -f $LEIN_PREFER ]]; then
-
-echo "Leiningen v2 not found, downloading..."
-
-./bin/get_lein.js
-
-chmod +x $LEIN_PREFER
-
+if [[ ! -x "$LEIN_PREFER" || "$LEIN_VER" =~ "$LEIN_VER1_PATTERN" ]]; then
+  >&2 echo "Leiningen v2 not found, downloading..."
+  >&2 download_lein
 fi
 
-if [[ ! -f $LEIN_PREFER ]]; then
-
-echo "Failed to find or set up Leiningen"
-exit 1
-
+if [ ! -x "$LEIN_PREFER" ]; then
+  echo "Failed to find or set up Leiningen"
+  exit 1
 fi
 
-$LEIN_PREFER $@
+"$LEIN_PREFER" $@

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "url": "git://github.com/swannodette/mori.git"
   },
   "engines": {
-      "node": ">=0.8.22"
+    "node": ">=0.8.22"
   },
-  "dependencies": {},
   "devDependencies": {
     "immutable": "3.5.0",
-    "jasmine-node": "1.7.0"
+    "jasmine-node": "1.7.0",
+    "wgetjs": "0.3.6"
   },
   "scripts": {
     "build": "./scripts/build.sh",
@@ -48,6 +48,6 @@
     "test": "jasmine-node spec"
   },
   "directories": {
-      "test": "./spec"
+    "test": "./spec"
   }
 }


### PR DESCRIPTION
I was having some trouble getting the mori build scripts to work. There were two issues that are fixed by these changes.

The get_lein script produced an empty file when I ran it. I updated that script to use the wgetjs library. You still get a download utility that does not have dependencies on anything other than node (despite the name), but the testing burden is shifted to a third party. I also updated the download URL.

The lein_prefer script silently failed for my when `which lein` failed to find a `lein` executable.
