### PR TITLE
Export type declarations for type-checking with Flow

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,6 @@
 [ignore]
 .*/flow-bin/.*
+.*[^e].json
 
 [include]
 

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,8 @@
+[ignore]
+.*/flow-bin/.*
+
+[include]
+
+[libs]
+
+[options]

--- a/mori.js.flow
+++ b/mori.js.flow
@@ -145,10 +145,12 @@ declare function assoc<K,V,S:Associative<K,V>>( coll: S
 declare function dissoc<K,V,S:Map<K,V>>(coll: S, ...keys: K[]): S
 declare function distinct<A,S:Indexed<A>>(coll: S): S
 declare function empty<A,S:Collection<A>>(coll: S): S
-declare var get: (<K,V>(coll: Associative<K,V>, key: K, notFound?: V) => ?V)  // TODO: `get` works on A[]
+declare var get: (<K,V>(coll: Associative<K,V>, key: K, notFound: V) => V)  // TODO: `get` works on A[]
+               & (<K,V>(coll: Associative<K,V>, key: K) => ?V)
                & (<K,V>(coll: Pair<K,V>, key: 0) => K)
                & (<K,V>(coll: Pair<K,V>, key: 1) => V)
-declare function getIn<K,V>(coll: Associative<K,any>, keys: Seqable<K>, notFound?: V): ?V
+declare var getIn: (<K,K_,V>(coll: Associative<K,any>, keys: Seqable<K&K_>, notFound: V) => V)
+                 & (<K,K_,V>(coll: Associative<K,any>, keys: Seqable<K&K_>) => ?V)
 declare function hasKey<K,V>(coll: Associative<K,V> | Set<K>, key: K): boolean  // TODO: `hasKey` works on A[]
 declare function find<K,V>(coll: Associative<K,V>, key: K): ?Pair<K,V>
 declare var nth: (<A>(coll: Indexed<A>, index: number) => ?A)

--- a/mori.js.flow
+++ b/mori.js.flow
@@ -19,6 +19,7 @@ declare function hash(x: any): number
  */
 declare class _Collection<A> {}
 declare class _Associative<K,V> {}
+declare class _Keyed<K,V> {}
 declare class _Seq<A>        extends _Collection<A> {}
 declare class _Sequential<A> extends _Collection<A> {}
 declare class _Stack<A>      extends _Collection<A> {}
@@ -28,6 +29,7 @@ declare class _Stack<A>      extends _Collection<A> {}
  */
 export type Collection<A>    = _Collection<A>
 export type Associative<K,V> = _Associative<K,V>
+export type Keyed<K,V>       = _Keyed<K,V>
 export type Seq<A>           = _Seq<A>
 export type Sequential<A>    = _Sequential<A>
 export type Stack<A>         = _Stack<A>
@@ -42,6 +44,7 @@ export type List<A> = Collection<A>
 
 export type Map<K,V> = Associative<K,V>
                      & Collection<Pair<K,V>>
+                     & Keyed<K,V>
 
 export type Queue<A> = Collection<A>
                      & Seq<A>
@@ -49,9 +52,11 @@ export type Queue<A> = Collection<A>
                      & Stack<A>
 
 export type Set<A> = Collection<A>
+                   & Keyed<A,A>
 
 export type Vector<A> = Associative<number,A>
                       & Collection<A>
+                      & Keyed<number,A>
                       & Sequential<A>
 
 /* Other Types */
@@ -145,13 +150,13 @@ declare function assoc<K,V,S:Associative<K,V>>( coll: S
 declare function dissoc<K,V,S:Map<K,V>>(coll: S, ...keys: K[]): S
 declare function distinct<A,S:Indexed<A>>(coll: S): S
 declare function empty<A,S:Collection<A>>(coll: S): S
-declare var get: (<K,V,V_>(coll: Associative<K,V>, key: K, notFound: V_) => V|V_)  // TODO: `get` works on A[]
-               & (<K,V>(coll: Associative<K,V>, key: K) => ?V)
+declare var get: (<K,V,V_>(coll: Keyed<K,V>, key: K, notFound: V_) => V|V_)  // TODO: `get` works on A[]
+               & (<K,V>(coll: Keyed<K,V>, key: K) => ?V)
                & (<K,V>(coll: Pair<K,V>, key: 0) => K)
                & (<K,V>(coll: Pair<K,V>, key: 1) => V)
-declare var getIn: (<K,K_,V,V_>(coll: Associative<K,any>, keys: Seqable<K&K_>, notFound: V_) => V|V_)
-                 & (<K,K_,V>(coll: Associative<K,any>, keys: Seqable<K&K_>) => ?V)
-declare function hasKey<K,V>(coll: Associative<K,V> | Set<K>, key: K): boolean  // TODO: `hasKey` works on A[]
+declare var getIn: (<K,K_,V,V_>(coll: Keyed<K,any>, keys: Seqable<K&K_>, notFound: V_) => V|V_)
+                 & (<K,K_,V>(coll: Keyed<K,any>, keys: Seqable<K&K_>) => ?V)
+declare function hasKey<K,V>(coll: Keyed<K,V>, key: K): boolean  // TODO: `hasKey` works on A[]
 declare function find<K,V>(coll: Associative<K,V>, key: K): ?Pair<K,V>
 declare var nth: (<A>(coll: Indexed<A>, index: number) => ?A)
                & (<K,V>(coll: Pair<K,V>, index: 0) => K)

--- a/mori.js.flow
+++ b/mori.js.flow
@@ -132,7 +132,6 @@ declare function isIndexed(coll: any): boolean
 declare function isReduceable(coll: any): boolean
 declare function isSeqable(coll: any): boolean
 declare function isReversible(coll: any): boolean
-declare function isCollection(coll: any): boolean
 declare function isKeyword(x: any): boolean
 declare function isSymbol(x: any): boolean
 
@@ -571,7 +570,6 @@ export {
   isReduceable,
   isSeqable,
   isReversible,
-  isCollection,
   isKeyword,
   isSymbol,
 

--- a/mori.js.flow
+++ b/mori.js.flow
@@ -548,8 +548,9 @@ declare var fnil: (<A,T,R>(f: (a: ?A, ...args: T[]) => R,
 declare var toClj: (<A,B>(x: A[]) => Vector<B>)
                  & (<A,B>(x: { [key: string]: A }) => Map<string,B>)
 
-declare var toJs: (<A,B>(x: Sequential<A> | Set<A>) => B[])
+declare var toJs: (<A,B>(x: Sequential<A> | Set<A> | Seq<A>) => B[])
                 & (<K,V,B>(x: Map<K,V>) => { [key: string]: B })
+                & (<K,V>(x: Pair<K,V>) => [K,V])
 
 /* Configure */
 

--- a/mori.js.flow
+++ b/mori.js.flow
@@ -145,11 +145,11 @@ declare function assoc<K,V,S:Associative<K,V>>( coll: S
 declare function dissoc<K,V,S:Map<K,V>>(coll: S, ...keys: K[]): S
 declare function distinct<A,S:Indexed<A>>(coll: S): S
 declare function empty<A,S:Collection<A>>(coll: S): S
-declare var get: (<K,V>(coll: Associative<K,V>, key: K, notFound: V) => V)  // TODO: `get` works on A[]
+declare var get: (<K,V,V_>(coll: Associative<K,V>, key: K, notFound: V_) => V|V_)  // TODO: `get` works on A[]
                & (<K,V>(coll: Associative<K,V>, key: K) => ?V)
                & (<K,V>(coll: Pair<K,V>, key: 0) => K)
                & (<K,V>(coll: Pair<K,V>, key: 1) => V)
-declare var getIn: (<K,K_,V>(coll: Associative<K,any>, keys: Seqable<K&K_>, notFound: V) => V)
+declare var getIn: (<K,K_,V,V_>(coll: Associative<K,any>, keys: Seqable<K&K_>, notFound: V_) => V|V_)
                  & (<K,K_,V>(coll: Associative<K,any>, keys: Seqable<K&K_>) => ?V)
 declare function hasKey<K,V>(coll: Associative<K,V> | Set<K>, key: K): boolean  // TODO: `hasKey` works on A[]
 declare function find<K,V>(coll: Associative<K,V>, key: K): ?Pair<K,V>
@@ -209,27 +209,31 @@ declare var map: (<A,B,C,D,E,R>(f: (a: A, b: B, c: C, d: D, e: E) => R,
                                 collb: Seqable<B>,
                                 collc: Seqable<C>,
                                 colld: Seqable<D>,
-                                colle: Seqable<E>
+                                colle: Seqable<E>,
+                                $?: null
                                ) => Seq<R>)
                & (<A,B,C,D,R>(f: (a: A, b: B, c: C, d: D) => R,
                               colla: Seqable<A>,
                               collb: Seqable<B>,
                               collc: Seqable<C>,
-                              colld: Seqable<D>
+                              colld: Seqable<D>,
+                              $?: null
                              ) => Seq<R>)
                & (<A,B,C,R>(f: (a: A, b: B, c: C) => R,
                             colla: Seqable<A>,
                             collb: Seqable<B>,
-                            collc: Seqable<C>
+                            collc: Seqable<C>,
+                            $?: null
                            ) => Seq<R>)
                & (<A,B,R>(f: (a: A, b: B) => R,
                           colla: Seqable<A>,
-                          collb: Seqable<B>
+                          collb: Seqable<B>,
+                          $?: null
                          ) => Seq<R>)
                & (<A,R>(f: (a: A) => R,
-                        colla: Seqable<A>
+                        colla: Seqable<A>,
+                        $?: null
                        ) => Seq<R>)
-
                & (<T,R>(f: (...values: T[]) => R,
                         ...colls: Seqable<T>[]
                         ) => Seq<R>)
@@ -239,25 +243,30 @@ declare var mapcat: (<A,B,C,D,E,R>(f: (a: A, b: B, c: C, d: D, e: E) => Seqable<
                                    collb: Seqable<B>,
                                    collc: Seqable<C>,
                                    colld: Seqable<D>,
-                                   colle: Seqable<E>
+                                   colle: Seqable<E>,
+                                   $?: null
                                   ) => Seq<R>)
                   & (<A,B,C,D,R>(f: (a: A, b: B, c: C, d: D) => Seqable<R>,
                                  colla: Seqable<A>,
                                  collb: Seqable<B>,
                                  collc: Seqable<C>,
-                                 colld: Seqable<D>
+                                 colld: Seqable<D>,
+                                 $?: null
                                 ) => Seq<R>)
                   & (<A,B,C,R>(f: (a: A, b: B, c: C) => Seqable<R>,
                                colla: Seqable<A>,
                                collb: Seqable<B>,
-                               collc: Seqable<C>
+                               collc: Seqable<C>,
+                               $?: null
                               ) => Seq<R>)
                   & (<A,B,R>(f: (a: A, b: B) => Seqable<R>,
                              colla: Seqable<A>,
-                             collb: Seqable<B>
+                             collb: Seqable<B>,
+                             $?: null
                             ) => Seq<R>)
                   & (<A,R>(f: (a: A) => Seqable<R>,
-                           colla: Seqable<A>
+                           colla: Seqable<A>,
+                           $?: null
                           ) => Seq<R>)
                   & (<T,R>(f: (...values: T[]) => Seqable<R>,
                            ...colls: Seqable<T>[]
@@ -271,7 +280,7 @@ declare var reduce: (<A,R>(f: (accum: R, value: A) => R,
                               ) => R)
                   & (<A,R>(f: (accum: R, value: A) => R,
                                coll: Seqable<A>
-                              ) => R)
+                              ) => ?R)
 declare function reduceKV<K,V,R>(f: (accum: R, key: K, value: V) => R,
                                  initial: R,
                                  coll: Associative<K,V>
@@ -315,49 +324,51 @@ declare function sum(...ns: number[]): number
 declare function isEven(n: number): boolean
 declare function isOdd(n: number): boolean
 
-declare var comp: (<A,B,C,D,E,F>(f4: (_: E) => F,
-                                 f3: (_: D) => E,
-                                 f2: (_: C) => D,
-                                 f1: (_: B) => C,
-                                 f0: (_: A) => B,
-                                ) => (_: A) => F)
-                & (<A,B,C,D,E>(f3: (_: D) => E,
-                               f2: (_: C) => D,
-                               f1: (_: B) => C,
-                               f0: (_: A) => B
-                              ) => (_: A) => E)
-                & (<A,B,C,D>(f2: (_: C) => D,
-                             f1: (_: B) => C,
-                             f0: (_: A) => B
-                            ) => (_: A) => D)
-                & (<A,B,C>(f1: (_: B) => C,
-                           f0: (_: A) => B
-                          ) => (_: A) => C)
-                & (<A,B>(f0: (_: A) => B
-                        ) => (_: A) => B)
-                & (<T,R>(...fs: ((_: T) => T)[]) => (_: T) => R)
+declare var comp: (<A,B,C,D,E>( fn3: (d: D) => E
+                              , fn2: (c: C) => D
+                              , fn1: (b: B) => C
+                              , fn0: (a: A) => B
+                              , $?: null
+                              ) => (a: A) => E)
+                & (<A,B,C,D>( fn2: (c: C) => D
+                            , fn1: (b: B) => C
+                            , fn0: (a: A) => B
+                            , $?: null
+                            ) => (a: A) => D)
+                & (<A,B,C>( fn1: (b: B) => C
+                          , fn0: (a: A) => B
+                          , $?: null
+                          ) => (a: A) => C)
+                & (<A,B>( fn0: (a: A) => B
+                        , $?: null
+                        ) => (a: A) => B)
 
 declare var juxt: (<T,A,B,C,D,E>(f0: (_: T) => A,
                                  f1: (_: T) => B,
                                  f2: (_: T) => C,
                                  f3: (_: T) => D,
-                                 f4: (_: T) => E
+                                 f4: (_: T) => E,
+                                 $?: null
                                 ) => (_: T) => [A,B,C,D,E])
                 & (<T,A,B,C,D>(f0: (_: T) => A,
                                f1: (_: T) => B,
                                f2: (_: T) => C,
-                               f3: (_: T) => D
+                               f3: (_: T) => D,
+                               $?: null
                               ) => (_: T) => [A,B,C,D])
                 & (<T,A,B,C>(f0: (_: T) => A,
                              f1: (_: T) => B,
-                             f2: (_: T) => C
+                             f2: (_: T) => C,
+                             $?: null
                             ) => (_: T) => [A,B,C])
                 & (<T,A,B>(f0: (_: T) => A,
-                           f1: (_: T) => B
+                           f1: (_: T) => B,
+                           $?: null
                           ) => (_: T) => [A,B])
-                & (<T,A>(f0: (_: T) => A
+                & (<T,A>(f0: (_: T) => A,
+                         $?: null
                         ) => (_: T) => [A])
-                & (<T>() => (_: T) => void[])
+                & (<T>($?: null) => (_: T) => void[])
                 & (<T,R>(f0: (_: T) => R,
                          f1: (_: T) => R,
                          f2: (_: T) => R,
@@ -371,23 +382,28 @@ declare var knit: (<T,A,B,C,D,E>(f0: (_: T) => A,
                                  f1: (_: T) => B,
                                  f2: (_: T) => C,
                                  f3: (_: T) => D,
-                                 f4: (_: T) => E
+                                 f4: (_: T) => E,
+                                 $?: null
                                 ) => (_: Seqable<T>) => [A,B,C,D,E])
                 & (<T,A,B,C,D>(f0: (_: T) => A,
                                f1: (_: T) => B,
                                f2: (_: T) => C,
-                               f3: (_: T) => D
+                               f3: (_: T) => D,
+                               $?: null
                               ) => (_: Seqable<T>) => [A,B,C,D])
                 & (<T,A,B,C>(f0: (_: T) => A,
                              f1: (_: T) => B,
-                             f2: (_: T) => C
+                             f2: (_: T) => C,
+                             $?: null
                             ) => (_: Seqable<T>) => [A,B,C])
                 & (<T,A,B>(f0: (_: T) => A,
-                           f1: (_: T) => B
+                           f1: (_: T) => B,
+                           $?: null
                           ) => (_: Seqable<T>) => [A,B])
-                & (<T,A>(f0: (_: T) => A
+                & (<T,A>(f0: (_: T) => A,
+                         $?: null
                         ) => (_: Seqable<T>) => [A])
-                & (<T>() => (_: Seqable<T>) => void[])
+                & (<T>($?: null) => (_: Seqable<T>) => void[])
                 & (<T,R>(f0: (_: T) => R,
                          f1: (_: T) => R,
                          f2: (_: T) => R,
@@ -402,50 +418,60 @@ declare var pipeline: (<A,B,C,D,E,R>(x: A,
                                      f1: (_: B) => C,
                                      f2: (_: C) => D,
                                      f3: (_: D) => E,
-                                     f4: (_: E) => R
+                                     f4: (_: E) => R,
+                                     $?: null
                                     ) => R)
                     & (<A,B,C,D,R>(x: A,
                                    f0: (_: A) => B,
                                    f1: (_: B) => C,
                                    f2: (_: C) => D,
                                    f3: (_: D) => R,
+                                   $?: null
                                   ) => R)
                     & (<A,B,C,R>(x: A,
                                  f0: (_: A) => B,
                                  f1: (_: B) => C,
                                  f2: (_: C) => R,
+                                 $?: null
                                 ) => R)
                     & (<A,B,R>(x: A,
                                f0: (_: A) => B,
                                f1: (_: B) => R,
+                               $?: null
                               ) => R)
                     & (<A,R>(x: A,
                              f0: (_: A) => R,
+                             $?: null
                             ) => R)
-                    & (<A>(x: A) => A)
+                    & (<A>(x: A, $?: null) => A)
                     & (<T,R>(x: T,
                              ...fs: ((_: T) => R)[]
                             ) => R)
 
-declare var partial: (<T,R>(f: (...args: T[]) => R
+declare var partial: (<T,R>(f: (...args: T[]) => R,
+                            $?: null
                          ) => (...args: T[]) => R)
                    & (<A,T,R>(f: (a: A, ...args: T[]) => R,
-                              a: A
+                              a: A,
+                              $?: null
                              ) => (...args: T[]) => R)
                    & (<A,B,T,R>(f: (a: A, b: B, ...args: T[]) => R,
                                 a: A,
                                 b: B,
+                                $?: null
                                ) => (...args: T[]) => R)
                    & (<A,B,C,T,R>(f: (a: A, b: B, c: C, ...args: T[]) => R,
                                   a: A,
                                   b: B,
                                   c: C,
+                                  $?: null
                                  ) => (...args: T[]) => R)
                    & (<A,B,C,D,T,R>(f: (a: A, b: B, c: C, d: D, ...args: T[]) => R,
                                     a: A,
                                     b: B,
                                     c: C,
                                     d: D,
+                                    $?: null
                                    ) => (...args: T[]) => R)
                    & (<A,B,C,D,E,T,R>(f: (a: A, b: B, c: C, d: D, e: E, ...args: T[]) => R,
                                       a: A,
@@ -453,34 +479,40 @@ declare var partial: (<T,R>(f: (...args: T[]) => R
                                       c: C,
                                       d: D,
                                       e: E,
+                                      $?: null
                                      ) => (...args: T[]) => R)
 
 declare var curry: typeof partial
 
 declare var fnil: (<A,T,R>(f: (a: ?A, ...args: T[]) => R,
-                           a: A
+                           a: A,
+                           $?: null
                           ) => (a: A, ...args: T[]) => R)
                 & (<A,B,T,R>(f: (a: ?A, b: ?B, ...args: T[]) => R,
                            a: A,
-                           b: B
+                           b: B,
+                           $?: null
                           ) => (a: A, b: B, ...args: T[]) => R)
                 & (<A,B,C,T,R>(f: (a: ?A, b: ?B, c: ?C, ...args: T[]) => R,
                                a: A,
                                b: B,
-                               c: C
+                               c: C,
+                               $?: null
                               ) => (a: A, b: B, c: C, ...args: T[]) => R)
                 & (<A,B,C,D,T,R>(f: (a: ?A, b: ?B, c: ?C, d: ?D, ...args: T[]) => R,
                                  a: A,
                                  b: B,
                                  c: C,
-                                 d: D
+                                 d: D,
+                                 $?: null
                                 ) => (a: A, b: B, c: C, d: D, ...args: T[]) => R)
                 & (<A,B,C,D,E,T,R>(f: (a: ?A, b: ?B, c: ?C, d: ?D, e: ?E, ...args: T[]) => R,
                                    a: A,
                                    b: B,
                                    c: C,
                                    d: D,
-                                   e: E
+                                   e: E,
+                                   $?: null
                                   ) => (a: A, b: B, c: C, d: D, e: E, ...args: T[]) => R)
 
 declare var toClj: (<A,B>(x: A[]) => Vector<B>)

--- a/mori.js.flow
+++ b/mori.js.flow
@@ -17,11 +17,20 @@ declare function hash(x: any): number
  * Class declarations happen to be a convenient way to make up types that are
  * unique to this module.
  */
-declare export class Collection<A> {}
-declare export class Associative<K,V> {}
-declare export class Seq<A>        extends Collection<A> {}
-declare export class Sequential<A> extends Collection<A> {}
-declare export class Stack<A>      extends Collection<A> {}
+declare class _Collection<A> {}
+declare class _Associative<K,V> {}
+declare class _Seq<A>        extends _Collection<A> {}
+declare class _Sequential<A> extends _Collection<A> {}
+declare class _Stack<A>      extends _Collection<A> {}
+
+/*
+ * Export types, but do not export non-existent class implementations.
+ */
+export type Collection<A>    = _Collection<A>
+export type Associative<K,V> = _Associative<K,V>
+export type Seq<A>           = _Seq<A>
+export type Sequential<A>    = _Sequential<A>
+export type Stack<A>         = _Stack<A>
 
 export type Indexed<A> = Sequential<A> | Iterable<A>
 export type Seqable<A> = Collection<A> | Iterable<A>

--- a/mori.js.flow
+++ b/mori.js.flow
@@ -192,7 +192,10 @@ declare function isSuperset<A,B>(seta: Set<A>, setb: Set<B>): boolean
 
 declare var first: (<A>(coll: Seqable<A>) => ?A)
                  & (<K,V>(coll: Pair<K,V>) => K)
+declare var second: (<A>(coll: Seqable<A>) => ?A)
+                  & (<K,V>(coll: Pair<K,V>) => V)
 declare function rest<A>(coll: Seqable<A>): Seq<A>
+declare function next<A>(coll: Seqable<A>): Seq<A>
 declare function seq<A>(coll: Seqable<A>): Seq<A>
 declare function cons<A,B>(value: A, coll: Seqable<B>): List<A|B>
 declare function concat<A,B>(coll: Seqable<A>, ...colls: Seqable<B>[]): Seq<A|B>
@@ -560,7 +563,9 @@ export {
   isSuperset,
 
   first,
+  second,
   rest,
+  next,
   seq,
   cons,
   concat,

--- a/mori.js.flow
+++ b/mori.js.flow
@@ -1,0 +1,580 @@
+/*
+ * Type definitions for Mori, for use with Flow type checker
+ *
+ * @flow
+ */
+
+/* Fundamentals */
+
+declare function equals(x: any, y: any): boolean
+declare function hash(x: any): number
+
+/* Collection Types */
+
+/*
+ * Declarations for classes that do not really exist.
+ * We need types to describe the capabilities of different collections.
+ * Class declarations happen to be a convenient way to make up types that are
+ * unique to this module.
+ */
+declare export class Collection<A> {}
+declare export class Associative<K,V> {}
+declare export class Seq<A>        extends Collection<A> {}
+declare export class Sequential<A> extends Collection<A> {}
+declare export class Stack<A>      extends Collection<A> {}
+
+export type Indexed<A> = Sequential<A> | Iterable<A>
+export type Seqable<A> = Collection<A> | Iterable<A>
+
+export type List<A> = Collection<A>
+                    & Seq<A>
+                    & Sequential<A>
+                    & Stack<A>
+
+export type Map<K,V> = Associative<K,V>
+                     & Collection<Pair<K,V>>
+
+export type Queue<A> = Collection<A>
+                     & Seq<A>
+                     & Sequential<A>
+                     & Stack<A>
+
+export type Set<A> = Collection<A>
+
+export type Vector<A> = Associative<number,A>
+                      & Collection<A>
+                      & Sequential<A>
+
+/* Other Types */
+
+/*
+ * A pair is just a vector. But by pretending that there is a distinct type
+ * called `Pair`, we get a representation at the type level that more closely
+ * matches usage of pairs when operating on `Map` values.
+ *
+ * With a distinct type, `get`, `nth`, `first`, and `last` can be checked with
+ * the knowledge that a pair from a map:
+ *
+ * - has exactly two values
+ * - has a value of type `K` in position 0
+ * - has a value of type `V` in position 1
+ *
+ * Furthermore, when building a map with `conj` or `into`, the distinct `Pair`
+ * type allows the type checker to verify that keys and values given match the
+ * key and value types for the map.
+ */
+declare export class Pair<K,V> {}
+
+declare export class Keyword {}
+declare export class Symbol {}
+
+/* Collection Constructors */
+
+declare function list<A>(...args: A[]): List<A>
+declare var vector: (<A>(...args: A[]) => Vector<A>)
+                  & (<K,V>(k: K, v: V) => Pair<K,V>)
+declare function hashMap<K,V>(...keysAndValues: (K | V)[]): Map<K,V>
+declare function sortedMap<K,V>(...keysAndValues: (K | V)[]): Map<K,V>
+declare function sortedMapBy<K,V>(cmp: (x: K, y: K) => number, ...keysAndValues: (K | V)[]): Map<K,V>
+declare function set<A>(values: Seqable<A>): Set<A>
+declare function sortedSet<A>(values: Seqable<A>): Set<A>
+declare function sortedSetBy<A>(cmp: (x: A, b: A) => number, ...values: A[]): Set<A>
+declare function range(start?: number, end?: number, step?: number): Seq<number>
+declare function queue<A>(...args: A[]): Queue<A>
+
+/* Other Constructors */
+
+declare function keyword(name: string): Keyword
+declare function symbol(name: string): Symbol
+
+/* Type Predicates */
+
+declare function isList(coll: any): boolean
+declare function isSeq(coll: any): boolean
+declare function isVector(coll: any): boolean
+declare function isMap(coll: any): boolean
+declare function isSet(coll: any): boolean
+declare function isCollection(coll: any): boolean
+declare function isSequential(coll: any): boolean
+declare function isAssociative(coll: any): boolean
+declare function isCounted(coll: any): boolean
+declare function isIndexed(coll: any): boolean
+declare function isReduceable(coll: any): boolean
+declare function isSeqable(coll: any): boolean
+declare function isReversible(coll: any): boolean
+declare function isCollection(coll: any): boolean
+declare function isKeyword(x: any): boolean
+declare function isSymbol(x: any): boolean
+
+/* Collection Operations */
+
+declare function conj<A,S:Collection<A>>(coll: S, ...args: A[]): S
+declare function into<A,T:Collection<A>,S:Seqable<A>>(coll: T, from: S): T
+declare function assoc<K,V,S:Associative<K,V>>(coll: S, ...keysAndValues: (K | V)[]): S
+declare function dissoc<K,V,S:Map<K,V>>(coll: S, ...keys: K[]): S
+declare function distinct<A,S:Indexed<A>>(coll: S): S
+declare function empty<A,S:Collection<A>>(coll: S): S
+declare var get: (<K,V>(coll: Associative<K,V>, key: K, notFound?: V) => ?V)  // TODO: `get` works on A[]
+               & (<K,V>(coll: Pair<K,V>, key: 0) => K)
+               & (<K,V>(coll: Pair<K,V>, key: 1) => V)
+declare function getIn<K,V>(coll: Associative<K,any>, keys: Seqable<K>, notFound?: V): ?V
+declare function hasKey<K,V>(coll: Associative<K,V> | Set<K>, key: K): boolean  // TODO: `hasKey` works on A[]
+declare function find<K,V>(coll: Associative<K,V>, key: K): ?Pair<K,V>
+declare var nth: (<A>(coll: Indexed<A>, index: number) => ?A)
+               & (<K,V>(coll: Pair<K,V>, index: 0) => K)
+               & (<K,V>(coll: Pair<K,V>, index: 1) => V)
+declare var last: (<A>(coll: Seqable<A>) => ?A)
+                & (<K,V>(coll: Pair<K,V>) => V)
+declare function assocIn<K,V,S:Associative<K,any>>(coll: S, keys: Seqable<K>, val: V): S
+declare function updateIn<K,V,S:Associative<K,any>>(coll: S,
+                                                    keys: Seqable<K>,
+                                                    f: (_: V) => V): S
+declare function count<A>(coll: Seqable<A>): number
+declare function isEmpty<A>(coll: Seqable<A>): boolean
+declare function peek<A>(coll: Stack<A>): ?A
+declare function pop<A,S:Stack<A>>(coll: S): S
+declare function zipmap<A,B>(xs: Seqable<A>, ys: Seqable<B>): Map<A,B>
+declare function reverse<A>(coll: Seqable<A>): Seq<A>
+
+/* Vector Operations */
+
+declare function subvec<A>(vec: Vector<A>, start: number, end?: number): Vector<A>
+
+/* Hash Map Operations */
+
+declare function keys<K,V>(map: Map<K,V>): Seq<K>
+declare function vals<K,V>(map: Map<K,V>): Seq<V>
+declare function merge<K,V,K_,V_>(map: Map<K,V>, ...maps: Map<K_,V_>[]): Map<K | K_,V | V_>
+
+/* Set Operations */
+
+declare function disj<A>(set: Set<A>, ...toRemove: A[]): Set<A>
+declare function union<A,B>(set: Set<A>, ...sets: Set<B>[]): Set<A | B>
+declare function intersection<A,B>(set: Set<A>, ...sets: Set<B>[]): Set<A & B>
+declare function difference<A,B>(set: Set<A>, ...sets: Set<B>[]): Set<A | B>
+declare function isSubset<A,B>(seta: Set<A>, setb: Set<B>): boolean
+declare function isSuperset<A,B>(seta: Set<A>, setb: Set<B>): boolean
+
+/* Sequences */
+
+declare var first: (<A>(coll: Seqable<A>) => ?A)
+                 & (<K,V>(coll: Pair<K,V>) => K)
+declare function rest<A>(coll: Seqable<A>): Seq<A>
+declare function seq<A>(coll: Seqable<A>): Seq<A>
+declare function cons<A,B>(value: A, coll: Seqable<B>): List<A|B>
+declare function concat<A,B>(coll: Seqable<A>, ...colls: Seqable<B>[]): Seq<A|B>
+declare function flatten<A>(coll: Seqable<any>): Seq<A>
+declare var intoArray: (<A>(coll: Seqable<A>) => A[])
+                     & (<K,V>(coll: Pair<K,V>) => [K,V])
+declare function each<A>(coll: Seqable<A>, f: (_: A) => any): void
+
+declare var map: (<A,B,C,D,E,R>(f: (a: A, b: B, c: C, d: D, e: E) => R,
+                                colla: Seqable<A>,
+                                collb: Seqable<B>,
+                                collc: Seqable<C>,
+                                colld: Seqable<D>,
+                                colle: Seqable<E>
+                               ) => Seq<R>)
+               & (<A,B,C,D,R>(f: (a: A, b: B, c: C, d: D) => R,
+                              colla: Seqable<A>,
+                              collb: Seqable<B>,
+                              collc: Seqable<C>,
+                              colld: Seqable<D>
+                             ) => Seq<R>)
+               & (<A,B,C,R>(f: (a: A, b: B, c: C) => R,
+                            colla: Seqable<A>,
+                            collb: Seqable<B>,
+                            collc: Seqable<C>
+                           ) => Seq<R>)
+               & (<A,B,R>(f: (a: A, b: B) => R,
+                          colla: Seqable<A>,
+                          collb: Seqable<B>
+                         ) => Seq<R>)
+               & (<A,R>(f: (a: A) => R,
+                        colla: Seqable<A>
+                       ) => Seq<R>)
+
+               & (<T,R>(f: (...values: T[]) => R,
+                        ...colls: Seqable<T>[]
+                        ) => Seq<R>)
+
+declare var mapcat: (<A,B,C,D,E,R>(f: (a: A, b: B, c: C, d: D, e: E) => Seqable<R>,
+                                   colla: Seqable<A>,
+                                   collb: Seqable<B>,
+                                   collc: Seqable<C>,
+                                   colld: Seqable<D>,
+                                   colle: Seqable<E>
+                                  ) => Seq<R>)
+                  & (<A,B,C,D,R>(f: (a: A, b: B, c: C, d: D) => Seqable<R>,
+                                 colla: Seqable<A>,
+                                 collb: Seqable<B>,
+                                 collc: Seqable<C>,
+                                 colld: Seqable<D>
+                                ) => Seq<R>)
+                  & (<A,B,C,R>(f: (a: A, b: B, c: C) => Seqable<R>,
+                               colla: Seqable<A>,
+                               collb: Seqable<B>,
+                               collc: Seqable<C>
+                              ) => Seq<R>)
+                  & (<A,B,R>(f: (a: A, b: B) => Seqable<R>,
+                             colla: Seqable<A>,
+                             collb: Seqable<B>
+                            ) => Seq<R>)
+                  & (<A,R>(f: (a: A) => Seqable<R>,
+                           colla: Seqable<A>
+                          ) => Seq<R>)
+                  & (<T,R>(f: (...values: T[]) => Seqable<R>,
+                           ...colls: Seqable<T>[]
+                           ) => Seq<R>)
+
+declare function filter<A>(pred: (value: A) => boolean, coll: Seqable<A>): Seq<A>
+declare function remove<A>(pred: (value: A) => boolean, coll: Seqable<A>): Seq<A>
+declare var reduce: (<A,R>(f: (accum: R, value: A) => R,
+                               initial: R,
+                               coll: Seqable<A>
+                              ) => R)
+                  & (<A,R>(f: (accum: R, value: A) => R,
+                               coll: Seqable<A>
+                              ) => R)
+declare function reduceKV<K,V,R>(f: (accum: R, key: K, value: V) => R,
+                                 initial: R,
+                                 coll: Associative<K,V>
+                                ): R
+declare function take<A>(n: number, coll: Seqable<A>): Seq<A>
+declare function takeWhile<A>(f: (value: A) => boolean, coll: Seqable<A>): Seq<A>
+declare function drop<A>(n: number, coll: Seqable<A>): Seq<A>
+declare function dropWhile<A>(f: (value: A) => boolean, coll: Seqable<A>): Seq<A>
+declare function some<A>(f: (value: A) => boolean, coll: Seqable<A>): ?A
+declare function every<A>(f: (value: A) => boolean, coll: Seqable<A>): boolean
+declare var sort: (<A>(cmp: (x: A, y: A) => number, coll: Seqable<A>) => Seq<A>)
+                & (<A>(coll: Seqable<A>) => Seq<A>)
+declare var sortBy: (<A,B>(keyfn: (x: A, y: A) => B, cmp: (x: B, y: B) => B, coll: Seqable<A>) => Seq<A>)
+                  & (<A,B>(keyfn: (x: A, y: A) => B, coll: Seqable<A>) => Seq<A>)
+declare function interpose<A,B>(x: B, coll: Seqable<A>): Seq<A|B>
+declare function interleave<A,B,C,D>(colla: Seqable<A>,
+                                     collb: Seqable<B>,
+                                     collc?: Seqable<C>,
+                                     ...colls: Seqable<D>[]
+                                    ): Seq<A|B|C|D>
+declare function iterate<A>(f: (value: A) => A, x: A): Seq<A>
+declare var repeat: (<A>(n: number, x: A) => Seq<A>)
+                  & (<A>(x: A) => Seq<A>)
+declare var repeatedly: (<A>(n: number, f: () => A) => Seq<A>)
+                      & (<A>(f: () => A) => Seq<A>)
+declare var partition: (<A,B>(n: number, step: number, pad: Seqable<B>, coll: Seqable<A>) => Seq<Seq<A|B>>)
+                     & (<A>(n: number, step: number, coll: Seqable<A>) => Seq<Seq<A>>)
+                     & (<A>(n: number, coll: Seqable<A>) => Seq<Seq<A>>)
+declare function partitionBy<K,A>(f: (value: A) => K, coll: Seqable<A>): Seq<Seq<A>>
+declare function groupBy<K,A>(f: (value: A) => K, coll: Seqable<A>): Map<K,Seq<A>>
+declare function lazySeq<A>(thunk: () => Seqable<A>): Seq<A>
+
+/* Helpers */
+
+declare function primSeq<A>(seqable: Seqable<A>, index?: number): Seq<A>
+declare function identity<A>(x: A): A
+declare function constantly<A>(x: A): (...args: any[]) => A
+declare function inc(n: number): number
+declare function dec(n: number): number
+declare function sum(...ns: number[]): number
+declare function isEven(n: number): boolean
+declare function isOdd(n: number): boolean
+
+declare var comp: (<A,B,C,D,E,F>(f4: (_: E) => F,
+                                 f3: (_: D) => E,
+                                 f2: (_: C) => D,
+                                 f1: (_: B) => C,
+                                 f0: (_: A) => B,
+                                ) => (_: A) => F)
+                & (<A,B,C,D,E>(f3: (_: D) => E,
+                               f2: (_: C) => D,
+                               f1: (_: B) => C,
+                               f0: (_: A) => B
+                              ) => (_: A) => E)
+                & (<A,B,C,D>(f2: (_: C) => D,
+                             f1: (_: B) => C,
+                             f0: (_: A) => B
+                            ) => (_: A) => D)
+                & (<A,B,C>(f1: (_: B) => C,
+                           f0: (_: A) => B
+                          ) => (_: A) => C)
+                & (<A,B>(f0: (_: A) => B
+                        ) => (_: A) => B)
+                & (<T,R>(...fs: ((_: T) => T)[]) => (_: T) => R)
+
+declare var juxt: (<T,A,B,C,D,E>(f0: (_: T) => A,
+                                 f1: (_: T) => B,
+                                 f2: (_: T) => C,
+                                 f3: (_: T) => D,
+                                 f4: (_: T) => E
+                                ) => (_: T) => [A,B,C,D,E])
+                & (<T,A,B,C,D>(f0: (_: T) => A,
+                               f1: (_: T) => B,
+                               f2: (_: T) => C,
+                               f3: (_: T) => D
+                              ) => (_: T) => [A,B,C,D])
+                & (<T,A,B,C>(f0: (_: T) => A,
+                             f1: (_: T) => B,
+                             f2: (_: T) => C
+                            ) => (_: T) => [A,B,C])
+                & (<T,A,B>(f0: (_: T) => A,
+                           f1: (_: T) => B
+                          ) => (_: T) => [A,B])
+                & (<T,A>(f0: (_: T) => A
+                        ) => (_: T) => [A])
+                & (<T>() => (_: T) => void[])
+                & (<T,R>(f0: (_: T) => R,
+                         f1: (_: T) => R,
+                         f2: (_: T) => R,
+                         f3: (_: T) => R,
+                         f4: (_: T) => R,
+                         f5: (_: T) => R,
+                         ...fs: ((_: T) => R)[]
+                        ) => (_: T) => R[])
+
+declare var knit: (<T,A,B,C,D,E>(f0: (_: T) => A,
+                                 f1: (_: T) => B,
+                                 f2: (_: T) => C,
+                                 f3: (_: T) => D,
+                                 f4: (_: T) => E
+                                ) => (_: Seqable<T>) => [A,B,C,D,E])
+                & (<T,A,B,C,D>(f0: (_: T) => A,
+                               f1: (_: T) => B,
+                               f2: (_: T) => C,
+                               f3: (_: T) => D
+                              ) => (_: Seqable<T>) => [A,B,C,D])
+                & (<T,A,B,C>(f0: (_: T) => A,
+                             f1: (_: T) => B,
+                             f2: (_: T) => C
+                            ) => (_: Seqable<T>) => [A,B,C])
+                & (<T,A,B>(f0: (_: T) => A,
+                           f1: (_: T) => B
+                          ) => (_: Seqable<T>) => [A,B])
+                & (<T,A>(f0: (_: T) => A
+                        ) => (_: Seqable<T>) => [A])
+                & (<T>() => (_: Seqable<T>) => void[])
+                & (<T,R>(f0: (_: T) => R,
+                         f1: (_: T) => R,
+                         f2: (_: T) => R,
+                         f3: (_: T) => R,
+                         f4: (_: T) => R,
+                         f5: (_: T) => R,
+                         ...fs: ((_: T) => R)[]
+                        ) => (_: Seqable<T>) => R[])
+
+declare var pipeline: (<A,B,C,D,E,R>(x: A,
+                                     f0: (_: A) => B,
+                                     f1: (_: B) => C,
+                                     f2: (_: C) => D,
+                                     f3: (_: D) => E,
+                                     f4: (_: E) => R
+                                    ) => R)
+                    & (<A,B,C,D,R>(x: A,
+                                   f0: (_: A) => B,
+                                   f1: (_: B) => C,
+                                   f2: (_: C) => D,
+                                   f3: (_: D) => R,
+                                  ) => R)
+                    & (<A,B,C,R>(x: A,
+                                 f0: (_: A) => B,
+                                 f1: (_: B) => C,
+                                 f2: (_: C) => R,
+                                ) => R)
+                    & (<A,B,R>(x: A,
+                               f0: (_: A) => B,
+                               f1: (_: B) => R,
+                              ) => R)
+                    & (<A,R>(x: A,
+                             f0: (_: A) => R,
+                            ) => R)
+                    & (<A>(x: A) => A)
+                    & (<T,R>(x: T,
+                             ...fs: ((_: T) => R)[]
+                            ) => R)
+
+declare var partial: (<T,R>(f: (...args: T[]) => R
+                         ) => (...args: T[]) => R)
+                   & (<A,T,R>(f: (a: A, ...args: T[]) => R,
+                              a: A
+                             ) => (...args: T[]) => R)
+                   & (<A,B,T,R>(f: (a: A, b: B, ...args: T[]) => R,
+                                a: A,
+                                b: B,
+                               ) => (...args: T[]) => R)
+                   & (<A,B,C,T,R>(f: (a: A, b: B, c: C, ...args: T[]) => R,
+                                  a: A,
+                                  b: B,
+                                  c: C,
+                                 ) => (...args: T[]) => R)
+                   & (<A,B,C,D,T,R>(f: (a: A, b: B, c: C, d: D, ...args: T[]) => R,
+                                    a: A,
+                                    b: B,
+                                    c: C,
+                                    d: D,
+                                   ) => (...args: T[]) => R)
+                   & (<A,B,C,D,E,T,R>(f: (a: A, b: B, c: C, d: D, e: E, ...args: T[]) => R,
+                                      a: A,
+                                      b: B,
+                                      c: C,
+                                      d: D,
+                                      e: E,
+                                     ) => (...args: T[]) => R)
+
+declare var curry: typeof partial
+
+declare var fnil: (<A,T,R>(f: (a: ?A, ...args: T[]) => R,
+                           a: A
+                          ) => (a: A, ...args: T[]) => R)
+                & (<A,B,T,R>(f: (a: ?A, b: ?B, ...args: T[]) => R,
+                           a: A,
+                           b: B
+                          ) => (a: A, b: B, ...args: T[]) => R)
+                & (<A,B,C,T,R>(f: (a: ?A, b: ?B, c: ?C, ...args: T[]) => R,
+                               a: A,
+                               b: B,
+                               c: C
+                              ) => (a: A, b: B, c: C, ...args: T[]) => R)
+                & (<A,B,C,D,T,R>(f: (a: ?A, b: ?B, c: ?C, d: ?D, ...args: T[]) => R,
+                                 a: A,
+                                 b: B,
+                                 c: C,
+                                 d: D
+                                ) => (a: A, b: B, c: C, d: D, ...args: T[]) => R)
+                & (<A,B,C,D,E,T,R>(f: (a: ?A, b: ?B, c: ?C, d: ?D, e: ?E, ...args: T[]) => R,
+                                   a: A,
+                                   b: B,
+                                   c: C,
+                                   d: D,
+                                   e: E
+                                  ) => (a: A, b: B, c: C, d: D, e: E, ...args: T[]) => R)
+
+declare var toClj: (<A,B>(x: A[]) => Vector<B>)
+                 & (<A,B>(x: { [key: string]: A }) => Map<string,B>)
+
+declare var toJs: (<A,B>(x: Sequential<A> | Set<A>) => B[])
+                & (<K,V,B>(x: Map<K,V>) => { [key: string]: B })
+
+/* Configure */
+
+declare function configure(setting: 'print-length' | 'print-level', value: ?number): void
+
+export {
+  equals,
+  hash,
+
+  isList,
+  isSeq,
+  isVector,
+  isMap,
+  isSet,
+  isCollection,
+  isSequential,
+  isAssociative,
+  isCounted,
+  isIndexed,
+  isReduceable,
+  isSeqable,
+  isReversible,
+  isCollection,
+  isKeyword,
+  isSymbol,
+
+  list,
+  vector,
+  hashMap,
+  sortedMap,
+  sortedMapBy,
+  set,
+  sortedSet,
+  sortedSetBy,
+  range,
+  queue,
+
+  keyword,
+  symbol,
+
+  conj,
+  into,
+  assoc,
+  dissoc,
+  distinct,
+  empty,
+  get,
+  getIn,
+  hasKey,
+  find,
+  nth,
+  last,
+  assocIn,
+  updateIn,
+  count,
+  isEmpty,
+  peek,
+  pop,
+  zipmap,
+  reverse,
+
+  subvec,
+
+  keys,
+  vals,
+  merge,
+
+  disj,
+  union,
+  intersection,
+  difference,
+  isSubset,
+  isSuperset,
+
+  first,
+  rest,
+  seq,
+  cons,
+  concat,
+  flatten,
+  intoArray,
+  each,
+  map,
+  mapcat,
+  filter,
+  remove,
+  reduce,
+  reduceKV,
+  take,
+  takeWhile,
+  drop,
+  dropWhile,
+  some,
+  every,
+  sort,
+  sortBy,
+  interpose,
+  interleave,
+  iterate,
+  repeat,
+  repeatedly,
+  partition,
+  partitionBy,
+  groupBy,
+  lazySeq,
+
+  primSeq,
+  identity,
+  constantly,
+  inc,
+  dec,
+  sum,
+  isEven,
+  isOdd,
+  comp,
+  juxt,
+  knit,
+  pipeline,
+  partial,
+  curry,
+  fnil,
+  toClj,
+  toJs,
+
+  configure,
+}

--- a/mori.js.flow
+++ b/mori.js.flow
@@ -82,6 +82,8 @@ declare export class Pair<K,V> {}
 declare export class Keyword {}
 declare export class Symbol {}
 
+type booleany = any
+
 /* Collection Constructors */
 
 declare function list<A>(...args: A[]): List<A>
@@ -276,8 +278,8 @@ declare var mapcat: (<A,B,C,D,E,R>(f: (a: A, b: B, c: C, d: D, e: E) => Seqable<
                            ...colls: Seqable<T>[]
                            ) => Seq<R>)
 
-declare function filter<A>(pred: (value: A) => boolean, coll: Seqable<A>): Seq<A>
-declare function remove<A>(pred: (value: A) => boolean, coll: Seqable<A>): Seq<A>
+declare function filter<A>(pred: (value: A) => booleany, coll: Seqable<A>): Seq<A>
+declare function remove<A>(pred: (value: A) => booleany, coll: Seqable<A>): Seq<A>
 declare var reduce: (<A,R>(f: (accum: R, value: A) => R,
                                initial: R,
                                coll: Seqable<A>
@@ -290,11 +292,11 @@ declare function reduceKV<K,V,R>(f: (accum: R, key: K, value: V) => R,
                                  coll: Associative<K,V>
                                 ): R
 declare function take<A>(n: number, coll: Seqable<A>): Seq<A>
-declare function takeWhile<A>(f: (value: A) => boolean, coll: Seqable<A>): Seq<A>
+declare function takeWhile<A>(f: (value: A) => booleany, coll: Seqable<A>): Seq<A>
 declare function drop<A>(n: number, coll: Seqable<A>): Seq<A>
-declare function dropWhile<A>(f: (value: A) => boolean, coll: Seqable<A>): Seq<A>
-declare function some<A>(f: (value: A) => boolean, coll: Seqable<A>): ?A
-declare function every<A>(f: (value: A) => boolean, coll: Seqable<A>): boolean
+declare function dropWhile<A>(f: (value: A) => booleany, coll: Seqable<A>): Seq<A>
+declare function some<A>(f: (value: A) => booleany, coll: Seqable<A>): ?A
+declare function every<A>(f: (value: A) => booleany, coll: Seqable<A>): boolean
 declare var sort: (<A>(cmp: (x: A, y: A) => number, coll: Seqable<A>) => Seq<A>)
                 & (<A>(coll: Seqable<A>) => Seq<A>)
 declare var sortBy: (<A,B>(keyfn: (x: A, y: A) => B, cmp: (x: B, y: B) => B, coll: Seqable<A>) => Seq<A>)

--- a/mori.js.flow
+++ b/mori.js.flow
@@ -454,32 +454,7 @@ declare var pipeline: (<A,B,C,D,E,R>(x: A,
                              ...fs: ((_: T) => R)[]
                             ) => R)
 
-declare var partial: (<T,R>(f: (...args: T[]) => R,
-                            $?: null
-                         ) => (...args: T[]) => R)
-                   & (<A,T,R>(f: (a: A, ...args: T[]) => R,
-                              a: A,
-                              $?: null
-                             ) => (...args: T[]) => R)
-                   & (<A,B,T,R>(f: (a: A, b: B, ...args: T[]) => R,
-                                a: A,
-                                b: B,
-                                $?: null
-                               ) => (...args: T[]) => R)
-                   & (<A,B,C,T,R>(f: (a: A, b: B, c: C, ...args: T[]) => R,
-                                  a: A,
-                                  b: B,
-                                  c: C,
-                                  $?: null
-                                 ) => (...args: T[]) => R)
-                   & (<A,B,C,D,T,R>(f: (a: A, b: B, c: C, d: D, ...args: T[]) => R,
-                                    a: A,
-                                    b: B,
-                                    c: C,
-                                    d: D,
-                                    $?: null
-                                   ) => (...args: T[]) => R)
-                   & (<A,B,C,D,E,T,R>(f: (a: A, b: B, c: C, d: D, e: E, ...args: T[]) => R,
+declare var partial: (<A,B,C,D,E,T,R>(f: (a: A, b: B, c: C, d: D, e: E, ...args: T[]) => R,
                                       a: A,
                                       b: B,
                                       c: C,
@@ -487,6 +462,31 @@ declare var partial: (<T,R>(f: (...args: T[]) => R,
                                       e: E,
                                       $?: null
                                      ) => (...args: T[]) => R)
+                   & (<A,B,C,D,T,R>(f: (a: A, b: B, c: C, d: D, ...args: T[]) => R,
+                                    a: A,
+                                    b: B,
+                                    c: C,
+                                    d: D,
+                                    $?: null
+                   & (<A,B,C,T,R>(f: (a: A, b: B, c: C, ...args: T[]) => R,
+                                  a: A,
+                                  b: B,
+                                  c: C,
+                                  $?: null
+                                 ) => (...args: T[]) => R)
+                   & (<A,B,T,R>(f: (a: A, b: B, ...args: T[]) => R,
+                                a: A,
+                                b: B,
+                                $?: null
+                               ) => (...args: T[]) => R)
+                                   ) => (...args: T[]) => R)
+                   & (<A,T,R>(f: (a: A, ...args: T[]) => R,
+                              a: A,
+                              $?: null
+                             ) => (...args: T[]) => R)
+                   & (<T,R>(f: (...args: T[]) => R,
+                            $?: null
+                         ) => (...args: T[]) => R)
 
 declare var curry: (<A,R>( f: (a: A) => R
                          , $?: null

--- a/mori.js.flow
+++ b/mori.js.flow
@@ -482,7 +482,31 @@ declare var partial: (<T,R>(f: (...args: T[]) => R,
                                       $?: null
                                      ) => (...args: T[]) => R)
 
-declare var curry: typeof partial
+declare var curry: (<A,R>( f: (a: A) => R
+                         , $?: null
+                         ) => (a: A) => R)
+                 & (<A,B,R>( f: (a: A, b: B) => R
+                           , b: B
+                           , $?: null
+                           ) => (a: A) => R)
+                 & (<A,B,C,R>( f: (a: A, b: B, c: C) => R
+                             , b: B
+                             , c: C
+                             , $?: null
+                             ) => (a: A) => R)
+                 & (<A,B,C,D,R>( f: (a: A, b: B, c: C, d: D) => R
+                               , b: B
+                               , c: C
+                               , d: D
+                               , $?: null
+                               ) => (a: A) => R)
+                 & (<A,B,C,D,E,R>( f: (a: A, b: B, c: C, d: D, e: E) => R
+                                 , b: B
+                                 , c: C
+                                 , d: D
+                                 , e: E
+                                 , $?: null
+                                 ) => (a: A) => R)
 
 declare var fnil: (<A,T,R>(f: (a: ?A, ...args: T[]) => R,
                            a: A,

--- a/mori.js.flow
+++ b/mori.js.flow
@@ -82,9 +82,25 @@ declare export class Symbol {}
 declare function list<A>(...args: A[]): List<A>
 declare var vector: (<A>(...args: A[]) => Vector<A>)
                   & (<K,V>(k: K, v: V) => Pair<K,V>)
-declare function hashMap<K,V>(...keysAndValues: (K | V)[]): Map<K,V>
-declare function sortedMap<K,V>(...keysAndValues: (K | V)[]): Map<K,V>
-declare function sortedMapBy<K,V>(cmp: (x: K, y: K) => number, ...keysAndValues: (K | V)[]): Map<K,V>
+declare function hashMap<K,V>( key0?: K, val0?: V
+                             , key1?: K, val1?: V
+                             , key2?: K, val2?: V
+                             , key3?: K, val3?: V
+                             , key4?: K, val4?: V
+                             , ...keysAndValues: (K | V)[]): Map<K,V>
+declare function sortedMap<K,V>( key0?: K, val0?: V
+                               , key1?: K, val1?: V
+                               , key2?: K, val2?: V
+                               , key3?: K, val3?: V
+                               , key4?: K, val4?: V
+                               , ...keysAndValues: (K | V)[]): Map<K,V>
+declare function sortedMapBy<K,V>( cmp: (x: K, y: K) => number
+                                 , key0?: K, val0?: V
+                                 , key1?: K, val1?: V
+                                 , key2?: K, val2?: V
+                                 , key3?: K, val3?: V
+                                 , key4?: K, val4?: V
+                                 , ...keysAndValues: (K | V)[]): Map<K,V>
 declare function set<A>(values: Seqable<A>): Set<A>
 declare function sortedSet<A>(values: Seqable<A>): Set<A>
 declare function sortedSetBy<A>(cmp: (x: A, b: A) => number, ...values: A[]): Set<A>
@@ -119,7 +135,13 @@ declare function isSymbol(x: any): boolean
 
 declare function conj<A,S:Collection<A>>(coll: S, ...args: A[]): S
 declare function into<A,T:Collection<A>,S:Seqable<A>>(coll: T, from: S): T
-declare function assoc<K,V,S:Associative<K,V>>(coll: S, ...keysAndValues: (K | V)[]): S
+declare function assoc<K,V,S:Associative<K,V>>( coll: S
+                                              , key0?: K, val0?: V
+                                              , key1?: K, val1?: V
+                                              , key2?: K, val2?: V
+                                              , key3?: K, val3?: V
+                                              , key4?: K, val4?: V
+                                              , ...keysAndValues: (K | V)[]): S
 declare function dissoc<K,V,S:Map<K,V>>(coll: S, ...keys: K[]): S
 declare function distinct<A,S:Indexed<A>>(coll: S): S
 declare function empty<A,S:Collection<A>>(coll: S): S

--- a/mori.js.flow
+++ b/mori.js.flow
@@ -157,10 +157,10 @@ declare var getIn: (<K,K_,V,V_>(coll: Keyed<K,any>, keys: Seqable<K&K_>, notFoun
                  & (<K,K_,V>(coll: Keyed<K,any>, keys: Seqable<K&K_>) => ?V)
 declare function hasKey<K,V>(coll: Keyed<K,V>, key: K): boolean  // TODO: `hasKey` works on A[]
 declare function find<K,V>(coll: Associative<K,V>, key: K): ?Pair<K,V>
-declare var nth: (<A>(coll: Indexed<A>, index: number) => ?A)
+declare var nth: (<A>(coll: Indexed<A>, index: number) => A)
                & (<K,V>(coll: Pair<K,V>, index: 0) => K)
                & (<K,V>(coll: Pair<K,V>, index: 1) => V)
-declare var last: (<A>(coll: Seqable<A>) => ?A)
+declare var last: (<A>(coll: Seqable<A>) => A)
                 & (<K,V>(coll: Pair<K,V>) => V)
 declare function assocIn<K,V,S:Associative<K,any>>(coll: S, keys: Seqable<K>, val: V): S
 declare function updateIn<K,V,S:Associative<K,any>>(coll: S,
@@ -168,7 +168,7 @@ declare function updateIn<K,V,S:Associative<K,any>>(coll: S,
                                                     f: (_: V) => V): S
 declare function count<A>(coll: Seqable<A>): number
 declare function isEmpty<A>(coll: Seqable<A>): boolean
-declare function peek<A>(coll: Stack<A>): ?A
+declare function peek<A>(coll: Stack<A>): A
 declare function pop<A,S:Stack<A>>(coll: S): S
 declare function zipmap<A,B>(xs: Seqable<A>, ys: Seqable<B>): Map<A,B>
 declare function reverse<A>(coll: Seqable<A>): Seq<A>
@@ -194,9 +194,9 @@ declare function isSuperset<A,B>(seta: Set<A>, setb: Set<B>): boolean
 
 /* Sequences */
 
-declare var first: (<A>(coll: Seqable<A>) => ?A)
+declare var first: (<A>(coll: Seqable<A>) => A)
                  & (<K,V>(coll: Pair<K,V>) => K)
-declare var second: (<A>(coll: Seqable<A>) => ?A)
+declare var second: (<A>(coll: Seqable<A>) => A)
                   & (<K,V>(coll: Pair<K,V>) => V)
 declare function rest<A>(coll: Seqable<A>): Seq<A>
 declare function next<A>(coll: Seqable<A>): Seq<A>

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "flow-bin": "0.21.0",
     "immutable": "3.5.0",
     "jasmine-node": "1.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "clean": "./scripts/clean.sh",
     "prepublish": "npm run-script build-clean",
     "docs": "./scripts/docs.sh",
-    "test": "jasmine-node spec"
+    "test": "jasmine-node spec",
+    "typecheck": "flow check"
   },
   "directories": {
       "test": "./spec"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "flow-bin": "0.21.0",
+    "flow-bin": "0.22.0",
     "immutable": "3.5.0",
     "jasmine-node": "1.7.0"
   },

--- a/spec/mori-spec.js
+++ b/spec/mori-spec.js
@@ -1,4 +1,10 @@
+/* @flow */
+
 var mori = require("../mori");
+
+/*:: declare var describe: Function */
+/*:: declare var it: Function */
+/*:: declare var expect: Function */
 
 describe("Map", function () {
     it("demonstrates mapping a function over a vector", function () {

--- a/spec/types-spec.js
+++ b/spec/types-spec.js
@@ -25,6 +25,12 @@ describe("type-checking", function () {
     mori.keys(m_);  // operation requires `Map<*,*>` type to be preserved
   });
 
+  it("returns default value when key is not found", function () {
+    var m = mori.hashMap('foo', 1, 'bar', 2);
+    var guaranteed/*: number */ = mori.get(m, 'nao', 3);
+    var not_guaranteed/*: ?number */ = mori.get(m, 'nao');
+  });
+
   it("creates consistently-typed zipmap", function () {
     var strings = mori.vector('foo', 'bar', 'nao');
     var numbers = mori.vector(1, 2, 3);

--- a/spec/types-spec.js
+++ b/spec/types-spec.js
@@ -99,6 +99,14 @@ describe("type-checking", function () {
     //var v_/*: Vector<string> */ = f(4);
   });
 
+  it("'curries' functions", function () {
+    var v/*: Vector<number> */ = mori.vector(1,2,3);
+    var f = mori.curry(mori.conj, 4);
+    var v_/*: Vector<number> */ = f(v);
+    // Does not type-check:
+    //var v_/*: Vector<string> */ = f(v);
+  });
+
   it("infers that a pair is guaranteed to have two elements with distinct types", function () {
     var m/*: Map<string,number> */ = mori.hashMap('foo', 1, 'bar', 2);
     var p = mori.first(m);

--- a/spec/types-spec.js
+++ b/spec/types-spec.js
@@ -1,0 +1,118 @@
+/*
+ * Extra specs to verify that certain operations pass type-checking.
+ *
+ * @flow
+ */
+
+var mori = require("../mori");
+
+/*:: declare var describe: Function */
+/*:: declare var it: Function */
+/*:: declare var expect: Function */
+
+/*:: import type { Collection, Map, Pair, Seq, Vector } from "../mori" */
+
+describe("type-checking", function () {
+
+  it("preserves collection type", function () {
+    var v  = mori.vector(1, 2, 3);
+    var v_ = mori.conj(v, 4);
+    mori.subvec(v_, 0);  // operation requires type to be a `Vector<*>`
+    var n/*: ?number */ = mori.first(v_);  // requires `number` type parameter to be preserved
+
+    var m  = mori.hashMap('foo', 1, 'bar', 2);
+    var m_ = mori.into(m, mori.list(mori.vector('nao', 3)))
+    mori.keys(m_);  // operation requires `Map<*,*>` type to be preserved
+  });
+
+  it("creates consistently-typed zipmap", function () {
+    var strings = mori.vector('foo', 'bar', 'nao');
+    var numbers = mori.vector(1, 2, 3);
+    var m = mori.zipmap(strings, numbers);
+    const s/*: ?string */ = mori.first(mori.keys(m));
+    const n/*: ?number */ = mori.first(mori.vals(m));
+  });
+
+  it("potentially broadens type of map on `merge`", function () {
+    var ma/*: Map<string,string> */ = mori.hashMap('foo', 'one', 'bar', 'two');
+    var mb/*: Map<number,number> */ = mori.hashMap(1, 1, 2, 2, 3, 3);
+    var m/*: Map<number|string,number|string> */  = mori.merge(ma, mb);
+  });
+
+  it("tracks input types for each transformation function in `map` and `mapcat`", function () {
+    var strings = mori.vector('foo', 'bar', 'nao');
+    var numbers = mori.vector(1, 2, 3);
+
+    var pairs/*: Seq<[string, number]> */ =
+      mori.map(function(s, n) { return [s, n]; }, strings, numbers);
+
+    var reps/*: Seq<string> */ =
+      mori.mapcat(function(s, n) { return mori.repeat(n, s); }, strings, numbers);
+  });
+
+  it("potentially broadens type of collection on `partition`", function () {
+    var numbers = mori.vector(1, 2, 3, 4, 5);
+    var padded/*: Seq<Seq<number|string>> */ = mori.partition(2, 2, 'xyz', numbers);
+    var unpadded/*: Seq<Seq<number>> */ =  mori.partition(2, numbers);
+  });
+
+  it("applies `primeSeq` to `arguments`", function () {
+    function asSeq() {
+      return mori.primSeq(arguments);
+    }
+    expect(mori.intoArray(asSeq(2,3))).toEqual([2,3])
+  });
+
+  it("composes functions, keeping track of type changes", function () {
+    var f = mori.comp(
+      (function(x) { return mori.count(x) > 2; }      /*: (_: Seq<string>) => boolean */),
+      (function(x) { return mori.repeat(x, 'foo'); }  /*: (_: number) => Seq<string> */),
+      (function(x) { return x.toLowerCase().length; } /*: (_: string) => number */)
+    );
+    var r1/*: boolean */ = f('foo');
+
+    var g = mori.comp(mori.isOdd, mori.inc);
+    var r2/*: boolean */ = g(3);
+  });
+
+  it("pipelines functions, keeping track of type changes", function () {
+    var r1/*: boolean */ = mori.pipeline('foo',
+      (function(x) { return x.toLowerCase().length; } /*: (_: string) => number */),
+      (function(x) { return mori.repeat(x, 'foo'); }  /*: (_: number) => Seq<string> */),
+      (function(x) { return mori.count(x) > 2; }      /*: (_: Seq<string>) => boolean */)
+    );
+
+    var r2/*: boolean */ = mori.pipeline(3, mori.inc, mori.isOdd);
+  });
+
+  it("partially applies functions", function () {
+    var v/*: Vector<number> */ = mori.vector(1,2,3);
+    var f = mori.partial(mori.conj, v);
+    var v_/*: Vector<number> */ = f(4);
+    // Does not type-check:
+    //var v_/*: Vector<string> */ = f(4);
+  });
+
+  it("infers that a pair is guaranteed to have two elements with distinct types", function () {
+    var m/*: Map<string,number> */ = mori.hashMap('foo', 1, 'bar', 2);
+    var p = mori.first(m);
+    if (!p) { return; }  // Assures the type-checker that `p` is not `null`
+
+    (mori.get(p, 0)/*: string */);
+    (mori.get(p, 1)/*: number */);
+
+    var v = mori.vector(1,2,3);
+    (mori.get(v, 2)/*: ?number */);
+  });
+
+  it("transforms a Mori pair into a native Javascript pair", function () {
+    // Producing a native array is useful for destructuring assignment.
+    var m/*: Map<string,number> */ = mori.hashMap('foo', 1, 'bar', 2);
+    var p = mori.first(m)
+    if (!p) { return; }  // Assures the type-checker that `p` is not `null`
+    var a = mori.intoArray(p)
+    var k/*: string */ = a[0]
+    var v/*: number */ = a[1]
+  })
+
+});


### PR DESCRIPTION
I am a big fan of Mori. I once wrote a [blog post](http://sitr.us/2013/11/04/functional-data-structures.html) on it.

More recently I have been enjoying the benefits of type-checked Javascript. I think that [Flow](http://sitr.us/2014/11/21/flow-is-the-javascript-type-checker-i-have-been-waiting-for.html) is especially good at describing and checking Javascript idioms. I get a lot of value from type-checking: it makes my code easier to refactor, it helps with documentation, and I get code that I trust. But when I use third-party data structures I lose type-checking, because Flow does not know anything about types in third-party code.

In this pull request I added type declarations for Mori functions in `mori.js.flow`. Flow will automatically read those declarations when Mori is included as a dependency. The type information will help users to catch silly problems early, whether they mark up their code with type annotations, or use Flow to check unadorned Javascript.

Because Flow is built to describe Javascript idioms, it can express types that are not possible in some strongly-typed languages. For example, a number of the type signatures that I wrote are aware of type-broadening. Here is the signature for `concat`:

``` js
declare function concat<A,B>(coll: Seqable<A>, ...colls: Seqable<B>[]): Seq<A|B>
```

The signature says that if collections containing different types of values are concatenated, the resulting sequence may contain values of types from any of the input collections. For example, if a vector of numbers and a vector of strings are concatenated, Flow will be aware that a value from the combined collection might be string or might be a number.

I was also able to capture the ability for `map`, `mapcat` to zip collections. The type signatures allow for an arbitrary number of collections to be combined. But for up to five collections, Flow will be able to check that types of values in the input collections match types of argument positions in the combining function.

The pull request includes some other changes:
- I added a couple of specially-formatted comments to the top of `mori-spec.js` so that Flow can check code there. I wanted to make sure that Flow did not flag any errors in the spec, since that would indicate that the type declarations are overly-restrictive.
- I added `flow-bin` to the project dev dependencies, and added a script in `package.json`. That allows for running Flow to check the specs with `npm run typecheck`.
- I added `types-spec.js` to test that some slightly tricky code patterns pass type-checking. `types-spec.js` does not have many assertions; but it does have type annotations in the form of specially-formatted comments.

Note that the type declarations apply to the Mori v0.3 API. I could modify them for v0.5; but I don't yet fully understand how to build v0.5.

I understand it is likely that you do not want to take on maintenance burden of a big pile of type annotations. I am happy to take ownership of issues relating to type-checking, and to handle updating type declarations for new versions of Mori's API. Having type declarations in Mori will dramatically improve my experience when using Mori in my own projects.
