### PR TITLE
add vec as PersistentVector.fromArray

### DIFF
--- a/src/mori/mori.cljs
+++ b/src/mori/mori.cljs
@@ -14,7 +14,7 @@
     into-array
     partial comp juxt
     identity constantly
-    list vector array-map hash-map zipmap set sorted-set keyword symbol
+    list vector vec array-map hash-map zipmap set sorted-set keyword symbol
     sorted-set-by sorted-map sorted-map-by
     sum inc dec even? odd? subseq compare
     meta with-meta vary-meta
@@ -116,6 +116,7 @@
 
 (mori-export list cljs.core/list)
 (mori-export vector cljs.core/vector)
+(mori-export vec cljs.core.PersistentVector.fromArray)
 (mori-export hashMap cljs.core/array-map)
 
 (mori-export set cljs.core/set)


### PR DESCRIPTION
I was running some performance tests on mori vs. immutable, and found that we could make vector creation from a JS array at least two times faster:

https://gist.github.com/edge/571bc3da31cb37d98addd78cc937f4d6
```
113 ms M linear conj
56 ms M atomic instance (apply)
28 ms M atomic instance (vec)
882 ms M js->clj
522 ms I linear push
238 ms I batched linear push
83 ms I atomic instance
215 ms I fromJS
```

The idiomatic way to create a vector with 100 zeroes (yielding 113 ms):
```js
let v = vector()
for (let i = 0; i < 100; i++) {
	v = conj(v, 0)
}
```

A slightly more efficient way (yielding 56 ms):
```js
const v = vector.apply(null, Array(100).fill(0))
```
However, this approach is limited to the number of arguments per call that the Javascript engine supports (though still quite a high number).

The `arguments` object is actually quite slow in Javascript, and this is [well documented](http://www.jspatterns.com/arguments-considered-harmful/).

By skipping [certain checks](https://github.com/clojure/clojurescript/blob/r1.9.495/src/main/cljs/cljs/core.cljs#L5255-L5260) when we know that we are instantiating from an array, we can eschew the expensive conversion (` [& args]`), avoid the function call limitation, and provide a cleaner interface (yielding 28 ms):
```js
const v = vec(Array(100).fill(0))
```

I also experimented with using `cljs.core/vec`, but found it even slower than the apply strategy, perhaps because PersistentVector.fromArray is that much more efficient.