### PR TITLE
docs: Fix simple typo, begining -> beginning

### DIFF
--- a/docs/js/shCore.js
+++ b/docs/js/shCore.js
@@ -925,7 +925,7 @@ function fixInputString(str)
 };
 
 /**
- * Removes all white space at the begining and end of a string.
+ * Removes all white space at the beginning and end of a string.
  * 
  * @param {String} str   String to trim.
  * @return {String}      Returns string without leading and following white space characters.
@@ -966,7 +966,7 @@ function unindent(str)
 		min = Math.min(matches[0].length, min);
 	}
 	
-	// trim minimum common number of white space from the begining of every line
+	// trim minimum common number of white space from the beginning of every line
 	if (min > 0) 
 		for (var i = 0; i < lines.length; i++) 
 			lines[i] = lines[i].substr(min);


### PR DESCRIPTION
There is a small typo in docs/js/shCore.js.

Should read `beginning` rather than `begining`.

